### PR TITLE
Allow renovate-automerge to operate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @powerhome/heroes-for-hire
+packages/**/*.gemspec
+packages/**/Gemfile


### PR DESCRIPTION
CODEOWNERS prevent renovate automerge since it will automatically ask for review
See documentation for more details: https://docs.renovatebot.com/automerge-configuration/

Solution: make files used by renovate owned by everyone