### PR TITLE
Ensure hashes can be converted to json

### DIFF
--- a/packages/lumberaxe/docs/CHANGELOG.md
+++ b/packages/lumberaxe/docs/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [Unreleased]
+
+## [0.1.2] - 2022-09-09
+
+- Ensure logging works without rails environments
+
+## [0.1.1] - 2022-07-28
+
+- Handles logging output formatting.

--- a/packages/lumberaxe/lib/lumberaxe.rb
+++ b/packages/lumberaxe/lib/lumberaxe.rb
@@ -4,6 +4,7 @@ require "logger"
 require "active_support"
 require "lumberaxe/logger"
 require "lumberaxe/json_formatter"
+require "json"
 
 module Lumberaxe
   def self.puma_formatter(level: "INFO", progname: "puma")

--- a/packages/lumberaxe/lib/lumberaxe/version.rb
+++ b/packages/lumberaxe/lib/lumberaxe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lumberaxe
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
+++ b/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
@@ -3,45 +3,57 @@
 require "rails_helper"
 
 RSpec.describe Lumberaxe, type: :request do
-  subject do
-    post "/campgrounds", params: { campground: { name: "Cloudland Canyon" }, format: :json }
+  context "with a standard request" do
+    subject do
+      post "/campgrounds", params: { campground: { name: "Cloudland Canyon" }, format: :json }
+    end
+
+    it "tags request_id" do
+      expect { subject }.to output(/"request_id":/).to_stdout_from_any_process
+    end
+
+    it "tags IP" do
+      expect { subject }.to output(/"IP":/).to_stdout_from_any_process
+    end
+
+    it "contains the defined progname" do
+      expect { subject }.to output(/"progname":"app"/).to_stdout_from_any_process
+    end
+
+    it "contains message key/value pairs" do
+      expect { subject }.to output(/"message":/).to_stdout_from_any_process
+    end
+
+    it "logs HTTP requests" do
+      expect { subject }.to output(%r{"method":"POST","path":"/campgrounds"}).to_stdout_from_any_process
+    end
+
+    it "logs any params" do
+      expect { subject }.to output(/"params":{"campground":{"name":"Cloudland Canyon"}/).to_stdout_from_any_process
+    end
+
+    it "logs anything passed to the rails logger" do
+      expect { subject }.to output(/Creating campground named Cloudland Canyon/).to_stdout_from_any_process
+    end
+
+    it "logs DB requests" do
+      expect { subject }.to output(/INSERT INTO/).to_stdout_from_any_process
+    end
+
+    it "logs error response" do
+      expect do
+        post "/campgrounds", params: { campground: { name: nil } }
+      end.to output(/"status":422/).to_stdout_from_any_process
+    end
   end
 
-  it "tags request_id" do
-    expect { subject }.to output(/"request_id":/).to_stdout_from_any_process
-  end
+  context "#puma_formatter" do
+    subject do
+      Lumberaxe.puma_formatter.call("test log message")
+    end
 
-  it "tags IP" do
-    expect { subject }.to output(/"IP":/).to_stdout_from_any_process
-  end
-
-  it "contains the defined progname" do
-    expect { subject }.to output(/"progname":"app"/).to_stdout_from_any_process
-  end
-
-  it "contains message key/value pairs" do
-    expect { subject }.to output(/"message":/).to_stdout_from_any_process
-  end
-
-  it "logs HTTP requests" do
-    expect { subject }.to output(%r{"method":"POST","path":"/campgrounds"}).to_stdout_from_any_process
-  end
-
-  it "logs any params" do
-    expect { subject }.to output(/"params":{"campground":{"name":"Cloudland Canyon"}/).to_stdout_from_any_process
-  end
-
-  it "logs anything passed to the rails logger" do
-    expect { subject }.to output(/Creating campground named Cloudland Canyon/).to_stdout_from_any_process
-  end
-
-  it "logs DB requests" do
-    expect { subject }.to output(/INSERT INTO/).to_stdout_from_any_process
-  end
-
-  it "logs error response" do
-    expect do
-      post "/campgrounds", params: { campground: { name: nil } }
-    end.to output(/"status":422/).to_stdout_from_any_process
+    it "returns log message" do
+      expect(subject).to include("test log message")
+    end
   end
 end


### PR DESCRIPTION
Unfortunately the `to_json` method is imported either by the `json` or `rails` libraries; ruby has no native way to convert this. 

This line was failing in environments where rails was not (or not _yet_) loaded.