### PR TITLE
Autocorrect rubocop failures

### DIFF
--- a/packages/audit_tracker/spec/audit_tracker_spec.rb
+++ b/packages/audit_tracker/spec/audit_tracker_spec.rb
@@ -4,10 +4,10 @@ require "spec_helper"
 
 RSpec.describe AuditTracker do
   describe "relationships", type: :model do
-    let(:lead) { ::Internal::Lead.new }
-    let(:sale) { ::Internal::Sale.new }
-    let(:score) { ::Internal::Score.new }
-    let(:home) { ::Internal::Home.new }
+    let(:lead) { Internal::Lead.new }
+    let(:sale) { Internal::Sale.new }
+    let(:score) { Internal::Score.new }
+    let(:home) { Internal::Home.new }
 
     it "sets up 'create' relationships for all trackers" do
       expect(lead).to belong_to(:created_by).class_name("::Internal::User")
@@ -43,42 +43,42 @@ RSpec.describe AuditTracker do
   end
 
   describe "data tracking" do
-    let(:marketing) { ::Internal::Department.create(name: "Marketing") }
+    let(:marketing) { Internal::Department.create(name: "Marketing") }
     let(:steve) do
-      ::Internal::User.create(
+      Internal::User.create(
         name: "Stephen Doe",
         department: marketing
       )
     end
-    let(:sales) { ::Internal::Department.create(name: "Sales") }
+    let(:sales) { Internal::Department.create(name: "Sales") }
     let(:john) do
-      ::Internal::User.create(
+      Internal::User.create(
         name: "John Doe",
         department: sales
       )
     end
 
     it "tracks the data on create" do
-      ::Internal::Current.user = john
-      created_lead = ::Internal::Lead.create
+      Internal::Current.user = john
+      created_lead = Internal::Lead.create
 
       expect(created_lead.created_by).to eql john
       expect(created_lead.created_by_department).to eql sales
     end
 
     it "tracks updates relationships on create" do
-      ::Internal::Current.user = john
-      created_lead = ::Internal::Lead.create
+      Internal::Current.user = john
+      created_lead = Internal::Lead.create
 
       expect(created_lead.updated_by).to eql john
       expect(created_lead.updated_by_department).to eql sales
     end
 
     it "tracks the data on update" do
-      ::Internal::Current.user = steve
-      created_lead = ::Internal::Lead.create
+      Internal::Current.user = steve
+      created_lead = Internal::Lead.create
 
-      ::Internal::Current.user = john
+      Internal::Current.user = john
       created_lead.update(strength: 100)
 
       expect(created_lead.created_by).to eql steve
@@ -88,20 +88,20 @@ RSpec.describe AuditTracker do
     end
 
     it "does not track data when the model does not have the required column" do
-      ::Internal::Current.user = steve
-      created_sale = ::Internal::Sale.create
+      Internal::Current.user = steve
+      created_sale = Internal::Sale.create
 
-      ::Internal::Current.user = john
+      Internal::Current.user = john
       created_sale.update(price: 100_000)
 
       expect(created_sale.updated_by).to eql john
     end
 
     it "is does not create relationships when the tracker is disabled" do
-      ::Internal::Current.user = steve
-      created_home = ::Internal::Home.create
+      Internal::Current.user = steve
+      created_home = Internal::Home.create
 
-      ::Internal::Current.user = john
+      Internal::Current.user = john
       created_home.update(price: 200_000)
 
       expect(created_home.created_by).to eql steve
@@ -109,21 +109,21 @@ RSpec.describe AuditTracker do
     end
 
     it "tracks data with the given overrides" do
-      ::Internal::Current.user = steve
-      created_score = ::Internal::Score.create
+      Internal::Current.user = steve
+      created_score = Internal::Score.create
 
-      ::Internal::Current.user = john
+      Internal::Current.user = john
       created_score.update(score: 10)
 
-      expect(created_score.created_by).to eql ::Internal::ManagerUser.find(steve.id)
-      expect(created_score.updated_by).to eql ::Internal::ManagerUser.find(john.id)
+      expect(created_score.created_by).to eql Internal::ManagerUser.find(steve.id)
+      expect(created_score.updated_by).to eql Internal::ManagerUser.find(john.id)
     end
 
     it "does not overwrite values manually set" do
-      ::Internal::Current.user = steve
-      created_home = ::Internal::Home.create(created_by: john, updated_by: john)
+      Internal::Current.user = steve
+      created_home = Internal::Home.create(created_by: john, updated_by: john)
 
-      ::Internal::Current.user = john
+      Internal::Current.user = john
       created_home.update(price: 100_00, updated_by: steve)
 
       expect(created_home.created_by).to eql john

--- a/packages/consent/spec/consent/ability_spec.rb
+++ b/packages/consent/spec/consent/ability_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe Consent::Ability do
   let(:permissions) do
     [
-      ::Consent::Permission.new(subject: ExampleModel, action: :update, view: "1"),
-      ::Consent::Permission.new(subject: ExampleModel, action: :report, view: :lol),
+      Consent::Permission.new(subject: ExampleModel, action: :update, view: "1"),
+      Consent::Permission.new(subject: ExampleModel, action: :report, view: :lol),
     ]
   end
   let(:user) { double(id: 1, role_id: 1) }

--- a/packages/consent/spec/consent/model_additions_spec.rb
+++ b/packages/consent/spec/consent/model_additions_spec.rb
@@ -20,7 +20,7 @@ describe Consent::ModelAdditions do
     let!(:rim) { ExampleModel.create! name: "Outer Rim", example_role_id: developer.id, additional_role_id: manager.id }
 
     let(:role_report_permission) do
-      ::Consent::Permission.new(subject: ExampleModel, action: :report, view: :role)
+      Consent::Permission.new(subject: ExampleModel, action: :report, view: :role)
     end
 
     let(:user) { double(role_id: developer.id, secondary_role_id: director.id) }

--- a/packages/consent/spec/consent/permission_migration_spec.rb
+++ b/packages/consent/spec/consent/permission_migration_spec.rb
@@ -9,7 +9,7 @@ describe Consent::PermissionMigration do
 
   describe ".copy_permissions" do
     it "creates a new permission based on the given permission" do
-      base_permission = ::Consent::Permission.create(role_id: 1, subject: :candidate, action: :access, view: :territory)
+      base_permission = Consent::Permission.create(role_id: 1, subject: :candidate, action: :access, view: :territory)
       expect(Consent::Permission.count).to eql 1
 
       copy_permissions(
@@ -37,11 +37,11 @@ describe Consent::PermissionMigration do
     end
 
     it "renames a subject affecting all grantted permissions keeping everything else" do
-      sale_perform_territory = ::Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
-                                                            view: :territory)
-      sale_perform_all = ::Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
-      sale_read_territory = ::Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
-      user_read_territory = ::Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
+      sale_perform_territory = Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
+                                                          view: :territory)
+      sale_perform_all = Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
+      sale_read_territory = Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
+      user_read_territory = Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
 
       update_permissions(
         from: { subject: :sale },
@@ -55,11 +55,11 @@ describe Consent::PermissionMigration do
     end
 
     it "can move an action from a subject to another keeping the view" do
-      sale_perform_territory = ::Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
-                                                            view: :territory)
-      sale_perform_all = ::Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
-      sale_read_territory = ::Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
-      user_read_territory = ::Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
+      sale_perform_territory = Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
+                                                          view: :territory)
+      sale_perform_all = Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
+      sale_read_territory = Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
+      user_read_territory = Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
 
       update_permissions(
         from: { subject: :sale, action: :perform },
@@ -73,11 +73,11 @@ describe Consent::PermissionMigration do
     end
 
     it "can rename an action within a subject keeping the view" do
-      sale_perform_territory = ::Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
-                                                            view: :territory)
-      sale_perform_all = ::Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
-      sale_read_territory = ::Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
-      user_read_territory = ::Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
+      sale_perform_territory = Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
+                                                          view: :territory)
+      sale_perform_all = Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
+      sale_read_territory = Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
+      user_read_territory = Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
 
       update_permissions(
         from: { subject: :sale, action: :read },
@@ -91,11 +91,11 @@ describe Consent::PermissionMigration do
     end
 
     it "can rename a view within a subject and action context" do
-      sale_perform_territory = ::Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
-                                                            view: :territory)
-      sale_perform_all = ::Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
-      sale_read_territory = ::Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
-      user_read_territory = ::Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
+      sale_perform_territory = Consent::Permission.create(role_id: 1, subject: :sale, action: :perform,
+                                                          view: :territory)
+      sale_perform_all = Consent::Permission.create(role_id: 2, subject: :sale, action: :perform, view: :all)
+      sale_read_territory = Consent::Permission.create(role_id: 4, subject: :sale, action: :read, view: :territory)
+      user_read_territory = Consent::Permission.create(role_id: 4, subject: :user, action: :read, view: :territory)
 
       update_permissions(
         from: { subject: :sale, action: :read, view: :territory },

--- a/packages/consent/spec/models/authorizable_spec.rb
+++ b/packages/consent/spec/models/authorizable_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe ::Consent::Authorizable, type: :model do
+RSpec.describe Consent::Authorizable, type: :model do
   describe "#grant" do
     let(:role) { ExampleRole.new }
 

--- a/packages/consent/spec/models/permission_spec.rb
+++ b/packages/consent/spec/models/permission_spec.rb
@@ -92,15 +92,15 @@ RSpec.describe Consent::Permission, type: :model do
 
   describe "#subject" do
     it "can be a class" do
-      permission = Consent::Permission.new(subject: ::MyModule::MyClass)
+      permission = Consent::Permission.new(subject: MyModule::MyClass)
 
-      expect(permission.subject).to be ::MyModule::MyClass
+      expect(permission.subject).to be MyModule::MyClass
     end
 
     it "can be set from a snake cased string" do
       permission = Consent::Permission.new(subject: "my_module/my_class")
 
-      expect(permission.subject).to be ::MyModule::MyClass
+      expect(permission.subject).to be MyModule::MyClass
     end
 
     it "can be serialized and reloaded" do
@@ -110,7 +110,7 @@ RSpec.describe Consent::Permission, type: :model do
         view: :all
       )
 
-      expect(permission.reload.subject).to be ::MyModule::MyClass
+      expect(permission.reload.subject).to be MyModule::MyClass
     end
   end
 


### PR DESCRIPTION
Not sure how these got onto the main branch, but they're making specs fail on PRs.

Example: https://github.com/powerhome/power-tools/actions/runs/3669714516/jobs/6203741959