### PR TITLE
Set GTID purged OFF to avoid table locks

### DIFF
--- a/packages/edgestitch/lib/edgestitch/mysql/dump.rb
+++ b/packages/edgestitch/lib/edgestitch/mysql/dump.rb
@@ -50,7 +50,7 @@ module Edgestitch
         return if tables.empty?
 
         self.class.sanitize_sql(
-          execute("--compact", "--skip-lock-tables", "--single-transaction", "--no-data",
+          execute("--compact", "--skip-lock-tables", "--single-transaction", "--no-data", "--set-gtid-purged=OFF",
                   "--column-statistics=0", *tables)
         )
       end
@@ -66,7 +66,7 @@ module Edgestitch
       def export_migrations(migrations)
         migrations.in_groups_of(50, false).map do |versions|
           execute(
-            "--compact", "--skip-lock-tables", "--single-transaction",
+            "--compact", "--skip-lock-tables", "--single-transaction", "--set-gtid-purged=OFF",
             "--no-create-info", "--column-statistics=0",
             "schema_migrations",
             "-w", "version IN (#{versions.join(',')})"

--- a/packages/edgestitch/lib/edgestitch/version.rb
+++ b/packages/edgestitch/lib/edgestitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Edgestitch
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Not setting this option leaves to the server configuration to decide, making it error prone depending on the user config. This option is not necessary for our database dump.

Also, enabling this might cause table locks:

> The data and the GTIDs backed up by mysqldump were inconsistent when the options --single-transaction and --set-gtid-purged=ON were both used. It was because in between the transaction started by mysqldump and the fetching of GTID_EXECUTED, GTIDs on the server could have increased already. With this fixed, a FLUSH TABLES WITH READ LOCK is performed before the fetching of GTID_EXECUTED to ensure its value is consistent with the snapshot taken by mysqldump.
>
> Our thanks to Marcelo Altmann for the contribution. (Bug #33630199)

This is documented as:

> Closes all open tables and locks all tables for all databases with a global read lock.

References:

* https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_set-gtid-purged
* https://github.com/powerhome/power-tools/blob/main/packages/edgestitch/lib/edgestitch/mysql/dump.rb#L68-L73
* https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-32.html
* https://dev.mysql.com/doc/refman/8.0/en/flush.html#flush-tables-with-read-lock
