### PR TITLE
Allow disabling rails tasks enhancing

### DIFF
--- a/packages/edgestitch/lib/edgestitch/tasks.rb
+++ b/packages/edgestitch/lib/edgestitch/tasks.rb
@@ -35,6 +35,7 @@ module Edgestitch
       # @return [Rake::Task]
       def define_stitch(namespace = "db:stitch", enhance_rails: true)
         enhance(namespace, "db:prepare", "db:structure:load", "db:schema:load") if enhance_rails
+
         desc "Create structure.sql for an app based on all loaded engines' structure-self.sql"
         task namespace => [:environment] do |_task, _args|
           ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
@@ -59,7 +60,7 @@ module Edgestitch
       # @param name [String] the name of the task within the given namespace [default: engine.engine_name]
       # @param enhance_rails [Boolean] whether edgestitch should enhance the above tasks or not [default: true]
       # @return [Rake::Task]
-      def define_engine(engine, namespace: "db:stitch", name: engine.engine_name, enhance_rails: true)
+      def define_engine(engine, namespace: "db:stitch", name: engine.engine_name, enhance_rails: true) # rubocop:disable Metrics/MethodLength
         if enhance_rails
           enhance("#{namespace}:#{name}", "db:structure:dump", "app:db:structure:dump", "db:schema:dump",
                   "app:db:schema:dump")

--- a/packages/edgestitch/lib/edgestitch/tasks.rb
+++ b/packages/edgestitch/lib/edgestitch/tasks.rb
@@ -31,8 +31,9 @@ module Edgestitch
       # - db:schema:load
       #
       # @param namespace [String] namespace where the task will run [default: db:stitch]
+      # @param enhance_rails [Boolean] whether edgestitch should enhance the above tasks or not [default: true]
       # @return [Rake::Task]
-      def define_stitch(namespace = "db:stitch")
+      def define_stitch(namespace = "db:stitch", enhance_rails: true)
         enhance(namespace, "db:prepare", "db:structure:load", "db:schema:load")
         desc "Create structure.sql for an app based on all loaded engines' structure-self.sql"
         task namespace => [:environment] do |_task, _args|
@@ -56,10 +57,11 @@ module Edgestitch
       # @param engine [Class<Rails::Engine>] target class of the task
       # @param namespace [String] the namespace where the target will be generated [default: db:stitch]
       # @param name [String] the name of the task within the given namespace [default: engine.engine_name]
+      # @param enhance_rails [Boolean] whether edgestitch should enhance the above tasks or not [default: true]
       # @return [Rake::Task]
-      def define_engine(engine, namespace: "db:stitch", name: engine.engine_name)
+      def define_engine(engine, namespace: "db:stitch", name: engine.engine_name, enhance_rails: true)
         enhance("#{namespace}:#{name}", "db:structure:dump", "app:db:structure:dump", "db:schema:dump",
-                "app:db:schema:dump")
+                "app:db:schema:dump") if enhance_rails
 
         desc "Create structure-self.sql for an engine"
         task "#{namespace}:#{name}" => [:environment] do |_, _args|

--- a/packages/edgestitch/lib/edgestitch/tasks.rb
+++ b/packages/edgestitch/lib/edgestitch/tasks.rb
@@ -34,7 +34,7 @@ module Edgestitch
       # @param enhance_rails [Boolean] whether edgestitch should enhance the above tasks or not [default: true]
       # @return [Rake::Task]
       def define_stitch(namespace = "db:stitch", enhance_rails: true)
-        enhance(namespace, "db:prepare", "db:structure:load", "db:schema:load")
+        enhance(namespace, "db:prepare", "db:structure:load", "db:schema:load") if enhance_rails
         desc "Create structure.sql for an app based on all loaded engines' structure-self.sql"
         task namespace => [:environment] do |_task, _args|
           ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
@@ -60,8 +60,10 @@ module Edgestitch
       # @param enhance_rails [Boolean] whether edgestitch should enhance the above tasks or not [default: true]
       # @return [Rake::Task]
       def define_engine(engine, namespace: "db:stitch", name: engine.engine_name, enhance_rails: true)
-        enhance("#{namespace}:#{name}", "db:structure:dump", "app:db:structure:dump", "db:schema:dump",
-                "app:db:schema:dump") if enhance_rails
+        if enhance_rails
+          enhance("#{namespace}:#{name}", "db:structure:dump", "app:db:structure:dump", "db:schema:dump",
+                  "app:db:schema:dump")
+        end
 
         desc "Create structure-self.sql for an engine"
         task "#{namespace}:#{name}" => [:environment] do |_, _args|


### PR DESCRIPTION
Allow disabling the rails tasks enhancements

A new version of mysqldump broke the generation of database dumps when GTID is enabled. This allow us to disable the db:stitch task enhancement on top of db:migrate when in deployment, where that is not necessary.