### PR TITLE
Remove `single-transaction` in attempt to stop read lock

### DIFF
--- a/packages/edgestitch/lib/edgestitch/mysql/dump.rb
+++ b/packages/edgestitch/lib/edgestitch/mysql/dump.rb
@@ -50,7 +50,7 @@ module Edgestitch
         return if tables.empty?
 
         self.class.sanitize_sql(
-          execute("--compact", "--skip-lock-tables", "--single-transaction", "--no-data", "--set-gtid-purged=OFF",
+          execute("--compact", "--skip-lock-tables", "--no-data", "--set-gtid-purged=OFF",
                   "--column-statistics=0", *tables)
         )
       end
@@ -66,7 +66,7 @@ module Edgestitch
       def export_migrations(migrations)
         migrations.in_groups_of(50, false).map do |versions|
           execute(
-            "--compact", "--skip-lock-tables", "--single-transaction", "--set-gtid-purged=OFF",
+            "--compact", "--skip-lock-tables", "--set-gtid-purged=OFF",
             "--no-create-info", "--column-statistics=0",
             "schema_migrations",
             "-w", "version IN (#{versions.join(',')})"

--- a/packages/edgestitch/lib/edgestitch/version.rb
+++ b/packages/edgestitch/lib/edgestitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Edgestitch
-  VERSION = "0.2.0"
+  VERSION = "0.4.0"
 end

--- a/packages/edgestitch/lib/edgestitch/version.rb
+++ b/packages/edgestitch/lib/edgestitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Edgestitch
-  VERSION = "0.4.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Locking tables is not desirable behavior for powerhome's infrastructure (and many others tbh)

From manpage:

```
8.0.31:

  --single-transaction
                      Creates a consistent snapshot by dumping all tables in a
                      single transaction. Works ONLY for tables stored in
                      storage engines which support multiversioning (currently
                      only InnoDB does); the dump is NOT guaranteed to be
                      consistent for other storage engines. While a
                      --single-transaction dump is in process, to ensure a
                      valid dump file (correct table contents and binary log
                      position), no other connection should use the following
                      statements: ALTER TABLE, DROP TABLE, RENAME TABLE,
                      TRUNCATE TABLE, as consistent snapshot is not isolated
                      from them. Option automatically turns off --lock-tables.
                  
```

We do not believe that this level of protection from dumping an inconsistent schema is necessary to our use case, and we can live without it. As of 8.0.31, Oracle introduced a table flush with read lock whenever any of `--single-transaction`, `--lock-all-tables` or `--master-data` are provided without updating the documentation to reflect this fact. Indeed, in the changelog they noted that this behaviour would only be enabled if BOTH `--single-transaction` was provided AND `--set-gtid-purged` was set to `ON` (typically automatically). [What they actually implemented](https://github.com/mysql/mysql-server/commit/022e73ba6976b984658a1c2652178cd4b81aec28#) did not include this conditional, and so https://github.com/powerhome/power-tools/pull/82, while desirable for its own reasons (why fetch GTIDs when we're going to massage them out anyway), did not avoid table flush with read lock. We believe this change will successfully avoid that obnoxious new behaviour.

References:

* https://bugs.mysql.com/bug.php?id=105761
* https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-32.html