### PR TITLE
Copy readme to root folder

### DIFF
--- a/.github/workflows/eslint-config.yml
+++ b/.github/workflows/eslint-config.yml
@@ -41,6 +41,8 @@ jobs:
           registry-url: ${{ env.REGISTRY_URL }}
       - run: yarn install --frozen-lockfile
         working-directory: ${{ env.PROJECT_DIR }}
+      - run: yarn expose-readme
+        working-directory: ${{ env.PROJECT_DIR }}
       - run: yarn publish
         working-directory: ${{ env.PROJECT_DIR }}
         env:

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,1 +1,0 @@
-docs/README.md

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "lint": "eslint lib/*",
     "prettier": "prettier -c --config ./lib/prettier.js .",
-    "prettier:write": "prettier --write --config ./lib/prettier.js ."
+    "prettier:write": "prettier --write --config ./lib/prettier.js .",
+    "expose-readme": "cp docs/README.md ."
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "5.47.0",


### PR DESCRIPTION
Adding a symlink to the README in the root folder was not allowed by NPM. So, let's copy the file to the root while publishing.