### PR TITLE
Work around bundler "dubious ownership" error

### DIFF
--- a/.github/workflows/_ruby-package.yml
+++ b/.github/workflows/_ruby-package.yml
@@ -56,6 +56,7 @@ jobs:
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v3
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         env:


### PR DESCRIPTION
This check is protecting us from something that's impossible in GH Actions.

See:

(https://github.com/actions/runner-images/issues/6775#issuecomment-1420586459
