### PR TITLE
Allow new rubocop versions

### DIFF
--- a/packages/cygnet/Gemfile.lock
+++ b/packages/cygnet/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.1)
+    rubocop-powerhome (0.5.2)
       rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
@@ -68,7 +68,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.44.1)
+    rubocop (1.45.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)

--- a/packages/cygnet/Gemfile.lock
+++ b/packages/cygnet/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../rubocop-powerhome
   specs:
     rubocop-powerhome (0.5.1)
-      rubocop (< 1.45.0)
+      rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
       rubocop-rake

--- a/packages/rabbet/Gemfile.lock
+++ b/packages/rabbet/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.1)
+    rubocop-powerhome (0.5.2)
       rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
@@ -198,7 +198,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.44.1)
+    rubocop (1.45.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)

--- a/packages/rabbet/Gemfile.lock
+++ b/packages/rabbet/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../rubocop-powerhome
   specs:
     rubocop-powerhome (0.5.1)
-      rubocop (< 1.45.0)
+      rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
       rubocop-rake

--- a/packages/rubocop-cobra/CHANGELOG.md
+++ b/packages/rubocop-cobra/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.2] - 2023-02-08
+
+- Permit Rubocop upgrades again because bug was fixed.
+
 ## [0.4.1] - 2023-02-08
 
 - Hold back version of Rubocop that's permitted due to incompatibility with our implementation.

--- a/packages/rubocop-cobra/Gemfile.lock
+++ b/packages/rubocop-cobra/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../rubocop-powerhome
   specs:
     rubocop-powerhome (0.5.1)
-      rubocop (< 1.45.0)
+      rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
       rubocop-rake
@@ -12,7 +12,7 @@ PATH
   remote: .
   specs:
     rubocop-cobra (0.4.1)
-      rubocop (< 1.45.0)
+      rubocop (~> 1.37)
       rubocop-powerhome
 
 GEM

--- a/packages/rubocop-cobra/Gemfile.lock
+++ b/packages/rubocop-cobra/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.1)
+    rubocop-powerhome (0.5.2)
       rubocop (~> 1.37)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    rubocop-cobra (0.4.1)
+    rubocop-cobra (0.4.2)
       rubocop (~> 1.37)
       rubocop-powerhome
 

--- a/packages/rubocop-cobra/lib/rubocop/cobra/version.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cobra/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Cobra
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end

--- a/packages/rubocop-cobra/rubocop-cobra.gemspec
+++ b/packages/rubocop-cobra/rubocop-cobra.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 
-  spec.add_runtime_dependency "rubocop", "< 1.45.0"
+  spec.add_runtime_dependency "rubocop", "~> 1.37"
   spec.add_runtime_dependency "rubocop-powerhome"
   spec.metadata["rubygems_mfa_required"] = "true"
 

--- a/packages/rubocop-powerhome/CHANGELOG.md
+++ b/packages/rubocop-powerhome/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.2] - 2023-02-08
+
+- Permit Rubocop upgrades again because bug was fixed.
+
 ## [0.5.1] - 2023-02-08
 
 - Hold back version of Rubocop that's permitted due to incompatibility with our implementation.

--- a/packages/rubocop-powerhome/lib/rubocop/powerhome/version.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/powerhome/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Powerhome
-    VERSION = "0.5.1"
+    VERSION = "0.5.2"
   end
 end

--- a/packages/rubocop-powerhome/rubocop-powerhome.gemspec
+++ b/packages/rubocop-powerhome/rubocop-powerhome.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 
-  spec.add_runtime_dependency "rubocop", "< 1.45.0"
+  spec.add_runtime_dependency "rubocop", "~> 1.37"
   spec.add_runtime_dependency "rubocop-performance"
   spec.add_runtime_dependency "rubocop-rails"
   spec.add_runtime_dependency "rubocop-rake"
@@ -47,5 +47,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", ">= 5.2.8.1", "< 7.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.37.0"
 end


### PR DESCRIPTION
The bug that caused all the drama [was fixed already](https://github.com/rubocop/rubocop/issues/11549).
