### PR TITLE
Revert "Work around bundler "dubious ownership" error"

### DIFF
--- a/.github/workflows/_ruby-package.yml
+++ b/.github/workflows/_ruby-package.yml
@@ -56,7 +56,6 @@ jobs:
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v3
-      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         env:


### PR DESCRIPTION
Reverts powerhome/power-tools#102 because it wasn't a valid fix.