### PR TITLE
Let bundler manage LOAD_PATH

### DIFF
--- a/packages/cygnet/cygnet.gemspec
+++ b/packages/cygnet/cygnet.gemspec
@@ -2,8 +2,6 @@
 
 require_relative "lib/cygnet/version"
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
-
 Gem::Specification.new do |s|
   s.name        = "cygnet"
   s.version     = Cygnet::VERSION
@@ -17,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "docs/README.md"]
+  s.require_paths = ["lib"]
 
   s.add_development_dependency "bundler", "~> 2.1"
   s.add_development_dependency "license_finder", "~> 7.0"

--- a/packages/edgestitch/edgestitch.gemspec
+++ b/packages/edgestitch/edgestitch.gemspec
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
-
 require "edgestitch/version"
 
 Gem::Specification.new do |spec|

--- a/packages/lumberaxe/lumberaxe.gemspec
+++ b/packages/lumberaxe/lumberaxe.gemspec
@@ -2,8 +2,6 @@
 
 require_relative "lib/lumberaxe/version"
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
-
 Gem::Specification.new do |spec|
   spec.name        = "lumberaxe"
   spec.version     = Lumberaxe::VERSION

--- a/packages/rabbet/rabbet.gemspec
+++ b/packages/rabbet/rabbet.gemspec
@@ -2,8 +2,6 @@
 
 require_relative "lib/rabbet/version"
 
-$LOAD_PATH.push File.expand_path("lib", __dir__)
-
 Gem::Specification.new do |s|
   s.name        = "rabbet"
   s.version     = Rabbet::VERSION
@@ -17,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["Rakefile", "docs/README.md"]
+  s.require_paths = ["lib"]
 
   s.add_dependency "cygnet", "0.0.1"
   s.add_dependency "rails", ">= 6.0"


### PR DESCRIPTION
Bundler should add the correct LOAD_PATH based on each Gemfile.
When we manipulate the LOAD_PATH like that we end adding dependencies to it
that are not declared. This happens because Bundler will parse and execute all
the gemspecs in a source (`source ".." do`), even when it ends up ignorign it.
