### PR TITLE
Inform RuboCop about loaded extensions

### DIFF
--- a/packages/rubocop-powerhome/lib/rubocop-powerhome.rb
+++ b/packages/rubocop-powerhome/lib/rubocop-powerhome.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 require "rubocop"
-require "rubocop-performance"
-require "rubocop-rails"
-require "rubocop-rake"
-require "rubocop-rspec"
 
 require_relative "rubocop/powerhome"
-
-RuboCop::Powerhome::Inject.defaults!
-
 require_relative "rubocop/cop/naming_cops"
 require_relative "rubocop/cop/style_cops"
+
+def load_rubocop_extension(extension)
+  RuboCop::ConfigLoader.add_loaded_features(extension)
+  require extension
+end
+
+load_rubocop_extension "rubocop-performance"
+load_rubocop_extension "rubocop-rails"
+load_rubocop_extension "rubocop-rake"
+load_rubocop_extension "rubocop-rspec"
+
+RuboCop::Powerhome::Inject.defaults!


### PR DESCRIPTION
Loading a rubocop extension is nothing but requiring a library, but rubocop likes to know what's loaded
so it can suggest you extensions that are loaded but not used.

https://github.com/rubocop/rubocop/blob/02c32b4cf3801f9cf4cca4b3f1f4288aaee2ad5c/lib/rubocop/options.rb#L304
