### PR TITLE
Fixes tagged logging

### DIFF
--- a/packages/lumberaxe/lib/lumberaxe/json_formatter.rb
+++ b/packages/lumberaxe/lib/lumberaxe/json_formatter.rb
@@ -7,13 +7,13 @@ module Lumberaxe
     include ActiveSupport::TaggedLogging::Formatter
 
     def call(severity, time, progname, data)
-      data = data.is_a?(Hash) ? format_data(data) : { message: data.to_s }
+      data = { message: data.to_s } unless data.is_a?(Hash)
 
       {
         level: severity,
         time: time,
         progname: progname,
-      }.merge(data).to_json.concat("\r\n")
+      }.merge(format_data(data)).to_json.concat("\r\n")
     end
 
     def format_data(data)

--- a/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
+++ b/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Lumberaxe, type: :request do
     it "logs any valid combination of tag formats" do
       expect do
         subject.tagged("omega", "pV=nRT", paink: "iller") { subject.info("brown") }
-      end.to output(%r{(?=.*"tags":\["omega",{"paink":"iller"}\])(?=.*"pV":"nRT")}).to_stdout_from_any_process
+      end.to output(/(?=.*"tags":\["omega",{"paink":"iller"}\])(?=.*"pV":"nRT")/).to_stdout_from_any_process
     end
   end
 end

--- a/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
+++ b/packages/lumberaxe/spec/lumberaxe/lumberaxe_spec.rb
@@ -62,4 +62,40 @@ RSpec.describe Lumberaxe, type: :request do
       expect(Rails.logger.silence { "test_silencer" }).to eq("test_silencer")
     end
   end
+
+  context "tagged logging" do
+    subject do
+      Lumberaxe::Logger.new(progname: "tagged_logging")
+    end
+
+    it "logs the message" do
+      expect do
+        subject.tagged("rose") { subject.info("bud") }
+      end.to output(/"message":"bud"/).to_stdout_from_any_process
+    end
+
+    it "logs tags" do
+      expect do
+        subject.tagged("hot", "sour") { subject.info("soup") }
+      end.to output(/"tags":\["hot","sour"\]/).to_stdout_from_any_process
+    end
+
+    it "logs tags as named keys" do
+      expect do
+        subject.tagged("evel=knievel") { subject.info("parachute") }
+      end.to output(/"evel":"knievel"/).to_stdout_from_any_process
+    end
+
+    it "logs hash tags" do
+      expect do
+        subject.tagged(hash: "alton") { subject.info("brown") }
+      end.to output(/"tags":\[{"hash":"alton"}\]/).to_stdout_from_any_process
+    end
+
+    it "logs any valid combination of tag formats" do
+      expect do
+        subject.tagged("omega", "pV=nRT", paink: "iller") { subject.info("brown") }
+      end.to output(%r{(?=.*"tags":\["omega",{"paink":"iller"}\])(?=.*"pV":"nRT")}).to_stdout_from_any_process
+    end
+  end
 end


### PR DESCRIPTION
Mainly just restores the JSON formatter to its old `LogChooser` algorithm:

https://github.com/powerhome/power-tools/pull/19/commits/c5f52dc93#diff-b5c693951741188b864854a97fd5cdc4eaa20c335ae29492f2c36d7877bb4965L29-L36