### PR TITLE
Alert on unsupported client

### DIFF
--- a/packages/rubocop-powerhome/lib/rubocop-powerhome.rb
+++ b/packages/rubocop-powerhome/lib/rubocop-powerhome.rb
@@ -5,6 +5,7 @@ require "rubocop"
 require_relative "rubocop/powerhome"
 require_relative "rubocop/cop/naming_cops"
 require_relative "rubocop/cop/style_cops"
+require_relative "rubocop/cop/tooling_cops"
 
 def load_rubocop_extension(extension)
   RuboCop::ConfigLoader.add_loaded_features(extension)

--- a/packages/rubocop-powerhome/lib/rubocop/cop/tooling/unsupported_client.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/tooling/unsupported_client.rb
@@ -1,0 +1,42 @@
+module RuboCop
+  module Cop
+    module Tooling
+      class UnsupportedClient < RuboCop::Cop::Cop
+        # TODO: Update this message to reference our internal wrapper and link to its documentation
+        MSG = "Found an unsupported HTTP client. Please use `Net::HTTP` instead."
+
+        HTTP_CLIENT_SEARCHES = {
+          faraday: '$(def $_ _args `(send (const nil? :Faraday) ...))',
+          # other clients
+        }
+
+        HTTP_CLIENT_SEARCHES.each { |client, definition| def_node_search(client, definition)  }
+
+        def_node_search :reference_calls, '$(def $_ _args `(send nil? %1))'
+
+        def on_class(node)
+          summary(node).each_with_object(default_hash) do |(matcher, def_nodes), refs|
+            def_nodes.each do |def_node|
+              reference_calls(node, def_node.method_name) do |def_node_ref|
+                refs[def_node.method_name][def_node_ref.method_name] = def_node_ref
+              end
+
+              add_offense(def_node, message: "Found #{matcher}!", severity: :fatal)
+            end
+          end
+        end
+
+        private
+
+        def summary(node)
+          HTTP_CLIENT_SEARCHES.keys.each_with_object(default_hash) do |matcher, summary|
+            public_send(matcher, node) { |def_node| summary[matcher].push(def_node) }
+          end
+        end
+
+        def default_hash
+          Hash.new { |h, k| h[k] = [] }
+        end
+      end
+    end
+  end

--- a/packages/rubocop-powerhome/lib/rubocop/cop/tooling_cops.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/tooling_cops.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Tooling
+      require_relative "tooling/unsupported_client"
+    end
+  end
+end

--- a/packages/rubocop-powerhome/spec/rubocop/cop/tooling/unsupported_client_spec.rb
+++ b/packages/rubocop-powerhome/spec/rubocop/cop/tooling/unsupported_client_spec.rb
@@ -5,19 +5,45 @@ require "spec_helper"
 RSpec.describe RuboCop::Cop::Tooling::UnsupportedClient do
   subject(:cop) { described_class.new }
 
-  context "when using Faraday" do
+  shared_examples "making HTTP calls for" do |key, http_class|
+    context "when using #{http_class}" do
+      let(:source) do
+        <<~RUBY
+          class Foo
+            def bar
+            ^^^^^^^ Tooling/UnsupportedClient: Found #{key}! Please use `Net::HTTP` instead.
+              #{http_class}.get("https://example.com")
+            end
+          end
+        RUBY
+      end
+
+      it "registers an offense" do
+        expect_offense(source)
+      end
+    end
+  end
+
+  context "when using Net::HTTP" do
     let(:source) do
       <<~RUBY
         class Foo
           def bar
-            Faraday.get("https://example.com")
+            # Invalid API doesn't matter here, we just care about not triggering the cop
+            Net::HTTP.get("https://example.com")
           end
         end
       RUBY
     end
 
-    it "registers an offense when Faraday is used" do
-      expect_offenses(source)
+    it "registers an offense when Net::HTTP is used" do
+      expect_no_offenses(source)
     end
   end
+
+  it_behaves_like "making HTTP calls for", :faraday, "Faraday"
+  it_behaves_like "making HTTP calls for", :httparty, "HTTParty"
+  it_behaves_like "making HTTP calls for", :rest_client, "RestClient"
+  it_behaves_like "making HTTP calls for", :typhoeus, "Typhoeus"
+  it_behaves_like "making HTTP calls for", :http_client, "HTTPClient"
 end

--- a/packages/rubocop-powerhome/spec/rubocop/cop/tooling/unsupported_client_spec.rb
+++ b/packages/rubocop-powerhome/spec/rubocop/cop/tooling/unsupported_client_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RuboCop::Cop::Tooling::UnsupportedClient do
+  subject(:cop) { described_class.new }
+
+  context "when using Faraday" do
+    let(:source) do
+      <<~RUBY
+        class Foo
+          def bar
+            Faraday.get("https://example.com")
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense when Faraday is used" do
+      expect_offenses(source)
+    end
+  end
+end


### PR DESCRIPTION
Followup - when we have our wrapper, we'll need to update the cop to disallow using Net::HTTP directly in favor of it.