### PR TITLE
Upgrade the Rails version to 7.1.3 for the lumberaxe library.

### DIFF
--- a/.github/workflows/lumberaxe.yml
+++ b/.github/workflows/lumberaxe.yml
@@ -9,5 +9,5 @@ jobs:
     with:
       package: ${{ github.workflow }}
       workdir: "packages/${{ github.workflow }}"
-      gemfiles: "['gemfiles/rails_6_0.gemfile','gemfiles/rails_6_1.gemfile','gemfiles/rails_7_0.gemfile']"
+      gemfiles: "['gemfiles/rails_6_0.gemfile','gemfiles/rails_6_1.gemfile','gemfiles/rails_7_0.gemfile','gemfiles/rails_7_1.gemfile']"
     secrets: inherit

--- a/packages/lumberaxe/Appraisals
+++ b/packages/lumberaxe/Appraisals
@@ -11,3 +11,7 @@ end
 appraise "rails-7-0" do
   gem "rails", "7.0.6"
 end
+
+appraise "rails-7-1" do
+  gem "rails", "7.1.3"
+end

--- a/packages/lumberaxe/Gemfile.lock
+++ b/packages/lumberaxe/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: .
   specs:
     lumberaxe (0.1.4)
-      activesupport (= 7.1.3)
+      activesupport (>= 6.0.6.1, < 7.2)
       lograge (= 0.10.0)
 
 GEM
@@ -318,7 +318,7 @@ DEPENDENCIES
   parser (>= 2.5, != 2.5.1.1)
   pry (>= 0.14.2)
   pry-byebug (= 3.10.1)
-  rails (>= 6.0.6.1, <= 7.1.3)
+  rails (>= 6.0.6.1, < 7.2)
   rainbow (= 2.2.2)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/packages/lumberaxe/Gemfile.lock
+++ b/packages/lumberaxe/Gemfile.lock
@@ -284,7 +284,7 @@ DEPENDENCIES
   parser (>= 2.5, != 2.5.1.1)
   pry (>= 0.14.2)
   pry-byebug (= 3.10.1)
-  rails (>= 6.0.6.1, < 7.1)
+  rails (>= 6.0.6.1, < 7.1.3)
   rainbow (= 2.2.2)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/packages/lumberaxe/gemfiles/rails_6_0.gemfile
+++ b/packages/lumberaxe/gemfiles/rails_6_0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "nokogiri", "< 1.16"
+gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "rails", "6.0.6.1"
 
 gemspec path: "../"

--- a/packages/lumberaxe/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_6_0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     lumberaxe (0.1.4)
-      activesupport (>= 6.0.6.1, < 7.1)
+      activesupport (>= 6.0.6.1, < 7.2)
       lograge (= 0.10.0)
 
 GEM

--- a/packages/lumberaxe/gemfiles/rails_6_1.gemfile
+++ b/packages/lumberaxe/gemfiles/rails_6_1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "nokogiri", "< 1.16"
+gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "rails", "6.1.7.4"
 
 gemspec path: "../"

--- a/packages/lumberaxe/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_6_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     lumberaxe (0.1.4)
-      activesupport (>= 6.0.6.1, < 7.1)
+      activesupport (>= 6.0.6.1, < 7.2)
       lograge (= 0.10.0)
 
 GEM

--- a/packages/lumberaxe/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     lumberaxe (0.1.4)
-      activesupport (>= 6.0.6.1, < 7.1)
+      activesupport (>= 6.0.6.1, < 7.2)
       lograge (= 0.10.0)
 
 GEM

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile
@@ -4,6 +4,6 @@ source "https://rubygems.org"
 
 gem "nokogiri", "< 1.16"
 gem "rubocop-powerhome", path: "../../rubocop-powerhome"
-gem "rails", "7.0.6"
+gem "rails", "7.1.3"
 
 gemspec path: "../"

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: ../rubocop-powerhome
+  remote: ../../rubocop-powerhome
   specs:
     rubocop-powerhome (0.5.2)
       rubocop (~> 1.52.0)
@@ -9,7 +9,7 @@ PATH
       rubocop-rspec
 
 PATH
-  remote: .
+  remote: ..
   specs:
     lumberaxe (0.1.4)
       activesupport (= 7.1.3)
@@ -102,7 +102,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    combustion (1.3.7)
+    combustion (1.4.0)
       activesupport (>= 3.0.0)
       railties (>= 3.0.0)
       thor (>= 0.14.6)
@@ -161,10 +161,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-linux)
-      racc (~> 1.4)
     parallel (1.24.0)
-    parser (3.3.0.2)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.3)
@@ -177,14 +175,14 @@ GEM
     psych (5.1.2)
       stringio
     racc (1.7.3)
-    rack (2.2.8)
-    rack-session (1.0.2)
-      rack (< 3)
+    rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (1.0.0)
-      rack (< 3)
-      webrick
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
     rails (7.1.3)
       actioncable (= 7.1.3)
       actionmailbox (= 7.1.3)
@@ -260,9 +258,9 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.0)
-      rubocop (~> 1.33)
-    rubocop-performance (1.20.1)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     rubocop-rails (2.23.1)
@@ -306,7 +304,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
-  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.1)
@@ -318,7 +315,7 @@ DEPENDENCIES
   parser (>= 2.5, != 2.5.1.1)
   pry (>= 0.14.2)
   pry-byebug (= 3.10.1)
-  rails (>= 6.0.6.1, <= 7.1.3)
+  rails (= 7.1.3)
   rainbow (= 2.2.2)
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
@@ -304,6 +304,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   appraisal (~> 2.4.1)

--- a/packages/lumberaxe/lumberaxe.gemspec
+++ b/packages/lumberaxe/lumberaxe.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0.6.1", "< 7.1"
+  spec.add_dependency "activesupport", "7.1.3"
   spec.add_dependency "lograge", "0.10.0"
 
   spec.add_development_dependency "appraisal", "~> 2.4.1"
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parser", ">= 2.5", "!= 2.5.1.1"
   spec.add_development_dependency "pry", ">= 0.14.2"
   spec.add_development_dependency "pry-byebug", "3.10.1"
-  spec.add_development_dependency "rails", ">= 6.0.6.1", "< 7.1.3"
+  spec.add_development_dependency "rails", ">= 6.0.6.1", "<= 7.1.3"
   spec.add_development_dependency "rainbow", "2.2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/packages/lumberaxe/lumberaxe.gemspec
+++ b/packages/lumberaxe/lumberaxe.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "7.1.3"
+  spec.add_dependency "activesupport", ">= 6.0.6.1", "<= 7.1"
   spec.add_dependency "lograge", "0.10.0"
 
   spec.add_development_dependency "appraisal", "~> 2.4.1"
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parser", ">= 2.5", "!= 2.5.1.1"
   spec.add_development_dependency "pry", ">= 0.14.2"
   spec.add_development_dependency "pry-byebug", "3.10.1"
-  spec.add_development_dependency "rails", ">= 6.0.6.1", "<= 7.1.3"
+  spec.add_development_dependency "rails", ">= 6.0.6.1", "<= 7.1"
   spec.add_development_dependency "rainbow", "2.2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/packages/lumberaxe/lumberaxe.gemspec
+++ b/packages/lumberaxe/lumberaxe.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0.6.1", "<= 7.1"
+  spec.add_dependency "activesupport", ">= 6.0.6.1", "< 7.2"
   spec.add_dependency "lograge", "0.10.0"
 
   spec.add_development_dependency "appraisal", "~> 2.4.1"
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parser", ">= 2.5", "!= 2.5.1.1"
   spec.add_development_dependency "pry", ">= 0.14.2"
   spec.add_development_dependency "pry-byebug", "3.10.1"
-  spec.add_development_dependency "rails", ">= 6.0.6.1", "<= 7.1"
+  spec.add_development_dependency "rails", ">= 6.0.6.1", "< 7.2"
   spec.add_development_dependency "rainbow", "2.2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/packages/lumberaxe/lumberaxe.gemspec
+++ b/packages/lumberaxe/lumberaxe.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "parser", ">= 2.5", "!= 2.5.1.1"
   spec.add_development_dependency "pry", ">= 0.14.2"
   spec.add_development_dependency "pry-byebug", "3.10.1"
-  spec.add_development_dependency "rails", ">= 6.0.6.1", "< 7.1"
+  spec.add_development_dependency "rails", ">= 6.0.6.1", "< 7.1.3"
   spec.add_development_dependency "rainbow", "2.2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
To address the [dependency conflict](https://github.com/powerhome/example-rails-app/pull/335) in the `example-rails-app` application, the team @powerhome/forever-people proposes upgrading the [rails gem to version 7.1.3](https://rubygems.org/gems/rails).