### PR TITLE
DepShield: Navigate around multiple returns

### DIFF
--- a/packages/dep_shield/Gemfile.lock
+++ b/packages/dep_shield/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    dep_shield (0.1.1)
+    dep_shield (0.1.2)
       nitro_config
       rails (>= 6.0.6.1, < 7.0)
       sentry-rails (= 5.5.0)

--- a/packages/dep_shield/lib/dep_shield/todos.rb
+++ b/packages/dep_shield/lib/dep_shield/todos.rb
@@ -7,7 +7,9 @@ module DepShield
         paths = Rails.root.glob("**/.deprecation_todo.yml")
 
         paths.each_with_object({}) do |path, list|
-          YAML.load_file(path)&.each do |feature_name, dep_todos|
+          todos = YAML.load_file(path) || []
+
+          todos.each do |feature_name, dep_todos|
             list[feature_name] ||= []
             list[feature_name] += dep_todos
           end

--- a/packages/dep_shield/lib/dep_shield/todos.rb
+++ b/packages/dep_shield/lib/dep_shield/todos.rb
@@ -7,7 +7,7 @@ module DepShield
         paths = Rails.root.glob("**/.deprecation_todo.yml")
 
         paths.each_with_object({}) do |path, list|
-          todos = YAML.load_file(path) || []
+          todos = YAML.load_file(path) || {}
 
           todos.each do |feature_name, dep_todos|
             list[feature_name] ||= []

--- a/packages/dep_shield/lib/dep_shield/version.rb
+++ b/packages/dep_shield/lib/dep_shield/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DepShield
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/packages/dep_shield/spec/internal/config/extra/.deprecation_todo.yml
+++ b/packages/dep_shield/spec/internal/config/extra/.deprecation_todo.yml
@@ -1,0 +1,12 @@
+# Using NitroErrors to mark something as deprecated means that it may raise when
+# new code using deprecated methods is introduced.
+# This file can be used to whitelist preexisting methods so that they will not raise,
+# and register a list of todos for places that should be fixed.
+# The intention is for the user to remove these configuration records
+# one by one as the deprecations are removed from the code base.
+#
+# More information: https://github.com/powerhome/nitro-web/blob/master/components/nitro_errors/docs/README.md#L1
+
+# Example:
+# test_deprecation_name:
+#   - app/controllers/example_controller.rb


### PR DESCRIPTION
Sometimes calling `YAML.load_file` on an empty file returns `nil`. Other times, it returns `false`. This accounts for both.