### PR TITLE
Minimize conflicts

### DIFF
--- a/packages/edgestitch/Gemfile.lock
+++ b/packages/edgestitch/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    edgestitch (0.3.0)
+    edgestitch (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/edgestitch/docs/CHANGELOG.md
+++ b/packages/edgestitch/docs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.0] - 2023-01-25
+
+- Minimize merge conflcits on structure-self.sql [#240](https://github.com/powerhome/power-tools/pull/240)
+- Let bundler manage LOAD_PATH alone [#111](https://github.com/powerhome/power-tools/pull/111)
+
 ## [0.3.0] - 2023-01-25
 
 - Allow disabling rails tasks enhancing by @xjunior in [#84](https://github.com/powerhome/power-tools/pull/84)

--- a/packages/edgestitch/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_6_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    edgestitch (0.3.0)
+    edgestitch (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/edgestitch/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_6_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    edgestitch (0.3.0)
+    edgestitch (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/edgestitch/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_7_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    edgestitch (0.3.0)
+    edgestitch (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/edgestitch/lib/edgestitch/mysql/dump.rb
+++ b/packages/edgestitch/lib/edgestitch/mysql/dump.rb
@@ -46,6 +46,7 @@ module Edgestitch
       def self.sanitize_migration_timestamps(sql)
         sql.gsub("VALUES ", "VALUES\n")
            .gsub(",", "\n,")
+           .gsub(";", "\n;")
       end
 
       #

--- a/packages/edgestitch/lib/edgestitch/mysql/dump.rb
+++ b/packages/edgestitch/lib/edgestitch/mysql/dump.rb
@@ -11,6 +11,8 @@ module Edgestitch
     # Wrapper for the mysqldump tool to dump specific tables and migration data
     #
     class Dump
+      # @private
+      #
       # Sanitizes a DDL code with some opinionated preferences:
       # * Constraints starting with `_fk` will start with `fk`
       # * Clear empty lines (with empty spaces even)
@@ -18,7 +20,7 @@ module Edgestitch
       #
       # @param sql [String] the DDL code to sanitize
       # @return String the same DDL sanitized
-      def self.sanitize_sql(sql)
+      def self.sanitize_create_table(sql)
         comment_instructions_regex = %r{^/\*![0-9]{5}\s+[^;]+;\s*$}
 
         cleanups = sql.gsub(/\s+AUTO_INCREMENT=\d+/, "")
@@ -27,6 +29,23 @@ module Edgestitch
                       .gsub(/\n\s*\n\s*\n/, "\n\n")
                       .strip
         ::Edgestitch::Mysql::StructureConstraintOrderMunger.munge(cleanups)
+      end
+
+      # @private
+      #
+      # Sanitizes a DML code to insert migration timestamps with opinionated preferences:
+      # * One timestamp per line
+      # * Except for the first line, they all start with a comma
+      # * Semicolomn is in a separate line from the last one
+      #
+      # The above preferences come from the idea of minimizing merge conflicts, or make
+      # them easily handled by git automatically
+      #
+      # @param sql [String] the DML code to sanitize
+      # @return String the same DML sanitized
+      def self.sanitize_migration_timestamps(sql)
+        sql.gsub("VALUES ", "VALUES\n")
+           .gsub(",", "\n,")
       end
 
       #
@@ -49,7 +68,7 @@ module Edgestitch
       def export_tables(tables)
         return if tables.empty?
 
-        self.class.sanitize_sql(
+        self.class.sanitize_create_table(
           execute("--compact", "--skip-lock-tables", "--no-data", "--set-gtid-purged=OFF",
                   "--column-statistics=0", *tables)
         )
@@ -65,13 +84,13 @@ module Edgestitch
       # @return String the INSERT statements.
       def export_migrations(migrations)
         migrations.in_groups_of(50, false).map do |versions|
-          execute(
+          self.class.sanitize_migration_timestamps execute(
             "--compact", "--skip-lock-tables", "--set-gtid-purged=OFF",
             "--no-create-info", "--column-statistics=0",
             "schema_migrations",
             "-w", "version IN (#{versions.join(',')})"
           )
-        end.join.gsub("VALUES ", "VALUES\n").gsub(",", ",\n")
+        end.join
       end
 
     private

--- a/packages/edgestitch/lib/edgestitch/version.rb
+++ b/packages/edgestitch/lib/edgestitch/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Edgestitch
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/packages/edgestitch/spec/dummy/config/application.rb
+++ b/packages/edgestitch/spec/dummy/config/application.rb
@@ -14,7 +14,7 @@ require_relative "../engines/sales/lib/sales/engine"
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 6.0
+    config.load_defaults Rails.version[0..2]
 
     config.active_record.schema_format = :sql
   end

--- a/packages/edgestitch/spec/edgestitch/mysql/dump_spec.rb
+++ b/packages/edgestitch/spec/edgestitch/mysql/dump_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Edgestitch::Mysql::Dump do
+  describe ".sanitize_migration_timestamps" do
+    it "breaks the insert down in different lines" do
+      insert = "INSERT INTO schema_migrations VALUES ('20240102123421'),('20240102223421')," \
+               "('20240102323421'),('20240102423421'),('20240102523421');"
+
+      sanitized = Edgestitch::Mysql::Dump.sanitize_migration_timestamps(insert)
+
+      # rubocop:disable Rails/SquishedSQLHeredocs
+      expect(sanitized).to eql <<~SQL.strip
+        INSERT INTO schema_migrations VALUES
+        ('20240102123421')
+        ,('20240102223421')
+        ,('20240102323421')
+        ,('20240102423421')
+        ,('20240102523421')
+        ;
+      SQL
+      # rubocop:enable Rails/SquishedSQLHeredocs
+    end
+  end
+end


### PR DESCRIPTION
Minimize merge conflicts

Based on:

https://github.com/lfittl/activerecord-clean-db-structure

- Extract sanitize_migration_timestamps to mysql
- Minimize conflicts in schema migrations
- Always load the defaults for the current version being tested
