### PR TITLE
Cleanup dep_shield dependencies including all of rails

### DIFF
--- a/packages/dep_shield/CHANGELOG.md
+++ b/packages/dep_shield/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.3.1]
+
+- Cleanup unnecessary dependencies and require of rails/all
+
 ## [0.3.0]
 
 - Subscribe to deprecation.rails notifications from railtie

--- a/packages/dep_shield/Gemfile.lock
+++ b/packages/dep_shield/Gemfile.lock
@@ -13,9 +13,7 @@ PATH
   specs:
     dep_shield (0.3.0)
       nitro_config
-      railties (>= 6.0.6.1, <= 7.0.6)
-      sentry-rails (= 5.5.0)
-      sentry-ruby (= 5.5.0)
+      sentry-ruby (>= 5.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -188,14 +186,6 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
     rspec-support (3.12.1)
     rubocop (1.52.1)
       json (~> 2.3)
@@ -229,9 +219,6 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sentry-rails (5.5.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.5.0)
     sentry-ruby (5.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sprockets (4.2.1)
@@ -269,7 +256,6 @@ DEPENDENCIES
   rails (<= 7.0.6)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rspec-rails (~> 5.1.2)
   rubocop-powerhome!
   sqlite3 (~> 1.4.2)
 

--- a/packages/dep_shield/Gemfile.lock
+++ b/packages/dep_shield/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    dep_shield (0.3.0)
+    dep_shield (0.3.1)
       nitro_config
       sentry-ruby (>= 5.5.0)
 

--- a/packages/dep_shield/dep_shield.gemspec
+++ b/packages/dep_shield/dep_shield.gemspec
@@ -32,14 +32,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nitro_config"
-  spec.add_dependency "railties", ">= 6.0.6.1", "<= 7.0.6"
-  spec.add_dependency "sentry-rails", "5.5.0"
-  spec.add_dependency "sentry-ruby", "5.5.0"
+  spec.add_dependency "sentry-ruby", ">= 5.5.0"
 
   spec.add_development_dependency "appraisal", "~> 2.5.0"
   spec.add_development_dependency "combustion", "~> 1.4"
   spec.add_development_dependency "license_finder", ">= 7.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-rails", "~> 5.1.2"
   spec.add_development_dependency "sqlite3", "~> 1.4.2"
 end

--- a/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
@@ -13,9 +13,7 @@ PATH
   specs:
     dep_shield (0.3.0)
       nitro_config
-      railties (>= 6.0.6.1, <= 7.0.6)
-      sentry-rails (= 5.5.0)
-      sentry-ruby (= 5.5.0)
+      sentry-ruby (>= 5.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -223,9 +221,6 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sentry-rails (5.5.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.5.0)
     sentry-ruby (5.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sprockets (4.2.1)

--- a/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    dep_shield (0.3.0)
+    dep_shield (0.3.1)
       nitro_config
       sentry-ruby (>= 5.5.0)
 
@@ -180,14 +180,6 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
     rspec-support (3.12.1)
     rubocop (1.52.1)
       json (~> 2.3)
@@ -259,7 +251,6 @@ DEPENDENCIES
   rails (= 6.0.6.1)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rspec-rails (~> 5.1.2)
   rubocop-powerhome!
   sqlite3 (~> 1.4.2)
 

--- a/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
@@ -13,9 +13,7 @@ PATH
   specs:
     dep_shield (0.3.0)
       nitro_config
-      railties (>= 6.0.6.1, <= 7.0.6)
-      sentry-rails (= 5.5.0)
-      sentry-ruby (= 5.5.0)
+      sentry-ruby (>= 5.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -227,9 +225,6 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sentry-rails (5.5.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.5.0)
     sentry-ruby (5.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sprockets (4.2.1)

--- a/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    dep_shield (0.3.0)
+    dep_shield (0.3.1)
       nitro_config
       sentry-ruby (>= 5.5.0)
 
@@ -184,14 +184,6 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
     rspec-support (3.12.1)
     rubocop (1.52.1)
       json (~> 2.3)
@@ -262,7 +254,6 @@ DEPENDENCIES
   rails (= 6.1.7.4)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rspec-rails (~> 5.1.2)
   rubocop-powerhome!
   sqlite3 (~> 1.4.2)
 

--- a/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
@@ -13,9 +13,7 @@ PATH
   specs:
     dep_shield (0.3.0)
       nitro_config
-      railties (>= 6.0.6.1, <= 7.0.6)
-      sentry-rails (= 5.5.0)
-      sentry-ruby (= 5.5.0)
+      sentry-ruby (>= 5.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -233,9 +231,6 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    sentry-rails (5.5.0)
-      railties (>= 5.0)
-      sentry-ruby (~> 5.5.0)
     sentry-ruby (5.5.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     sqlite3 (1.4.4)

--- a/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    dep_shield (0.3.0)
+    dep_shield (0.3.1)
       nitro_config
       sentry-ruby (>= 5.5.0)
 
@@ -190,14 +190,6 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
     rspec-support (3.12.1)
     rubocop (1.52.1)
       json (~> 2.3)
@@ -261,7 +253,6 @@ DEPENDENCIES
   rails (= 7.0.6)
   rake (~> 13.0)
   rspec (~> 3.0)
-  rspec-rails (~> 5.1.2)
   rubocop-powerhome!
   sqlite3 (~> 1.4.2)
 

--- a/packages/dep_shield/lib/dep_shield.rb
+++ b/packages/dep_shield/lib/dep_shield.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "nitro_config"
-require "rails/all"
-require "sentry-rails"
 require "sentry-ruby"
 
 require_relative "dep_shield/deprecation"

--- a/packages/dep_shield/lib/dep_shield/version.rb
+++ b/packages/dep_shield/lib/dep_shield/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DepShield
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/packages/dep_shield/spec/spec_helper.rb
+++ b/packages/dep_shield/spec/spec_helper.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
 require "bundler"
-require "dep_shield/railtie"
-require "rspec/rails"
-
 Bundler.require :default, :development
+require "dep_shield/railtie"
 
 Combustion.initialize! :all
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = true
-
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 


### PR DESCRIPTION
- Remove optional dependency "railties" (users of the railtie include the railtie)
- remove unused dependency "sentry-rails"
- Remove require of `rails/all`