### PR TITLE
Disallow empty saved_changes in camel_trail

### DIFF
--- a/packages/camel_trail/lib/camel_trail/recordable.rb
+++ b/packages/camel_trail/lib/camel_trail/recordable.rb
@@ -21,6 +21,9 @@ module CamelTrail
     def __record_changes
       activity = new_record? ? :created : :updated
       yield
+
+      return if saved_changes.blank?
+
       CamelTrail.record!(self, activity, __camel_trail_source_changes,
                          CamelTrail::Config.current_session_user_id&.call)
     end

--- a/packages/camel_trail/spec/camel_trail/recordable_spec.rb
+++ b/packages/camel_trail/spec/camel_trail/recordable_spec.rb
@@ -56,4 +56,13 @@ RSpec.describe CamelTrail::Recordable do
     # Changed negative price to 0
     expect(last_truck_history.source_changes).to include("price" => [nil, 0])
   end
+
+  it "does not save empty source_changes" do
+    allow_any_instance_of(Truck).to receive(:saved_changes).and_return({})
+
+    truck = Truck.create! name: "I am empty on the inside"
+    last_truck_history = CamelTrail.for(truck)
+
+    expect(last_truck_history).to eql []
+  end
 end


### PR DESCRIPTION
Allowing `camel_trail` to record changes that are empty (`{}`) should not be possible. If no changes are present, return. This prevents useless records from being created.