### PR TITLE
Fix data taster flavor date

### DIFF
--- a/packages/data_taster/Gemfile.lock
+++ b/packages/data_taster/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    data_taster (0.4.0)
+    data_taster (0.4.1)
       nokogiri (= 1.17.2)
       rails (>= 6.0)
 

--- a/packages/data_taster/docs/CHANGELOG.md
+++ b/packages/data_taster/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.1] - 2025-02-27
+
+- Fix date flavor for newer rails versions
+
 ## [0.3.0] - 2024-04-25
 
 - Add compatibility for encryption with newer versions of attr_encrypted

--- a/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
@@ -11,7 +11,8 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.0)
+    data_taster (0.4.1)
+      nokogiri (= 1.17.2)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
@@ -11,7 +11,8 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.0)
+    data_taster (0.4.1)
+      nokogiri (= 1.17.2)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
@@ -11,7 +11,8 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.0)
+    data_taster (0.4.1)
+      nokogiri (= 1.17.2)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/lib/data_taster/flavors.rb
+++ b/packages/data_taster/lib/data_taster/flavors.rb
@@ -12,9 +12,9 @@ module DataTaster
 
     def date
       @date ||= if DataTaster.config.months
-                  (current_date - DataTaster.config.months.to_i.months).beginning_of_day.to_s(:db)
+                  (current_date - DataTaster.config.months.to_i.months).beginning_of_day.to_formatted_s(:db)
                 else
-                  (current_date - 1.week).beginning_of_day.to_s(:db)
+                  (current_date - 1.week).beginning_of_day.to_formatted_s(:db)
                 end
     end
 

--- a/packages/data_taster/lib/data_taster/version.rb
+++ b/packages/data_taster/lib/data_taster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DataTaster
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Rails 7.0 depreated the use of `to_s` for date formatting, in favor of `to_fs` or `to_formatted_s`, being the later present in more versions of rails.

- **Fix DataTasterFlavors#date**
- **Bump DataTaster version**
