### PR TITLE
Lower nokogiri requirement on data taster gemspec

### DIFF
--- a/packages/data_taster/Gemfile.lock
+++ b/packages/data_taster/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: .
   specs:
     data_taster (0.4.1)
-      nokogiri (= 1.17.2)
+      nokogiri (> 1.14.0)
       rails (>= 6.0)
 
 GEM
@@ -143,7 +143,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
     minitest (5.25.4)
     mutex_m (0.3.0)
     net-imap (0.4.18)
@@ -156,8 +155,17 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.17.2)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.17.2-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.2-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.17.2-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.17.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.17.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.26.3)
     parser (3.3.7.0)

--- a/packages/data_taster/Gemfile.lock
+++ b/packages/data_taster/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    data_taster (0.4.1)
+    data_taster (0.4.2)
       nokogiri (> 1.14.0)
       rails (>= 6.0)
 

--- a/packages/data_taster/data_taster.gemspec
+++ b/packages/data_taster/data_taster.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "1.17.2" # can be removed after we remove support for Rails 6.0.1
+  spec.add_dependency "nokogiri", "> 1.14.0" # can be removed after we remove support for Rails 6.0.1
   spec.add_dependency "rails", ">= 6.0"
 
   spec.add_development_dependency "license_finder", "~> 7.0"

--- a/packages/data_taster/docs/CHANGELOG.md
+++ b/packages/data_taster/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.2] - 2025-02-27
+
+- Lower nokogiri requirement to 1.14
+
 ## [0.4.1] - 2025-02-27
 
 - Fix date flavor for newer rails versions

--- a/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.1)
+    data_taster (0.4.2)
       nokogiri (> 1.14.0)
       rails (>= 6.0)
 

--- a/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     data_taster (0.4.1)
-      nokogiri (= 1.17.2)
+      nokogiri (> 1.14.0)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.1)
+    data_taster (0.4.2)
       nokogiri (> 1.14.0)
       rails (>= 6.0)
 

--- a/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     data_taster (0.4.1)
-      nokogiri (= 1.17.2)
+      nokogiri (> 1.14.0)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    data_taster (0.4.1)
+    data_taster (0.4.2)
       nokogiri (> 1.14.0)
       rails (>= 6.0)
 

--- a/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: ..
   specs:
     data_taster (0.4.1)
-      nokogiri (= 1.17.2)
+      nokogiri (> 1.14.0)
       rails (>= 6.0)
 
 GEM

--- a/packages/data_taster/lib/data_taster/version.rb
+++ b/packages/data_taster/lib/data_taster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DataTaster
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
Our upstream systems need a lower requirement for nokogiri.

- **Lower the requirement for nokogiri on data taster**
- **Release 0.4.2**
