### PR TITLE
Fix Rubocop inheritance warning

### DIFF
--- a/packages/aether_observatory/Gemfile.lock
+++ b/packages/aether_observatory/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/aether_observatory/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/aether_observatory/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/aether_observatory/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/aether_observatory/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/aether_observatory/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/aether_observatory/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/aether_observatory/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/aether_observatory/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/audit_tracker/Gemfile.lock
+++ b/packages/audit_tracker/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/audit_tracker/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/audit_tracker/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/audit_tracker/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/audit_tracker/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/audit_tracker/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/audit_tracker/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/camel_trail/Gemfile.lock
+++ b/packages/camel_trail/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/camel_trail/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/camel_trail/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/camel_trail/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/camel_trail/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/camel_trail/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/camel_trail/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/consent/Gemfile.lock
+++ b/packages/consent/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/consent/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/consent/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/consent/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/consent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/cygnet/Gemfile.lock
+++ b/packages/cygnet/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/cygnet/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/cygnet/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/cygnet/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/cygnet/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/cygnet/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/cygnet/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_conduit/Gemfile.lock
+++ b/packages/data_conduit/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_conduit/gemfiles/sequel_5.90.gemfile.lock
+++ b/packages/data_conduit/gemfiles/sequel_5.90.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_conduit/gemfiles/sequel_latest.gemfile.lock
+++ b/packages/data_conduit/gemfiles/sequel_latest.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_taster/Gemfile.lock
+++ b/packages/data_taster/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/data_taster/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/dep_shield/Gemfile.lock
+++ b/packages/dep_shield/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_0.gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_6_1.gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_0.gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/dep_shield/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_1.gemfile.lock
@@ -7,7 +7,7 @@ PATH
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/edgestitch/Gemfile.lock
+++ b/packages/edgestitch/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/edgestitch/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/edgestitch/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/edgestitch/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/edgestitch/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/lumberaxe/Gemfile.lock
+++ b/packages/lumberaxe/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/lumberaxe/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/lumberaxe/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/lumberaxe/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/nitro_config/Gemfile.lock
+++ b/packages/nitro_config/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/nitro_config/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/nitro_config/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/nitro_config/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/nitro_config/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/nitro_config/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/nitro_config/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/nitro_config/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/nitro_config/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rabbet/Gemfile.lock
+++ b/packages/rabbet/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rubocop-cobra/.rubocop_todo.yml
+++ b/packages/rubocop-cobra/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 19
-
 # Offense count: 14
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
@@ -21,3 +16,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
   Max: 11
+
+Metrics/AbcSize:
+  Exclude:
+  - lib/rubocop/cop/cobra/model_file_placement.rb
+  - lib/rubocop/cop/cobra/controller_file_placement.rb

--- a/packages/rubocop-cobra/CHANGELOG.md
+++ b/packages/rubocop-cobra/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.4.5] - 2025-04-22
+
 - Fix Rubocop base class inheritance [#323](https://github.com/powerhome/power-tools/pull/323)
 
 ## [0.4.4] - 2023-03-18

--- a/packages/rubocop-cobra/CHANGELOG.md
+++ b/packages/rubocop-cobra/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix Rubocop base class inheritance [#323](https://github.com/powerhome/power-tools/pull/323)
+
 ## [0.4.4] - 2023-03-18
 
 - Bump Rubocop version to bring in bugfixes.

--- a/packages/rubocop-cobra/Gemfile.lock
+++ b/packages/rubocop-cobra/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    rubocop-cobra (0.4.4)
+    rubocop-cobra (0.4.5)
       rubocop (= 1.74.0)
       rubocop-powerhome
 

--- a/packages/rubocop-cobra/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/rubocop-cobra/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    rubocop-cobra (0.4.4)
+    rubocop-cobra (0.4.5)
       rubocop (= 1.74.0)
       rubocop-powerhome
 

--- a/packages/rubocop-cobra/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/rubocop-cobra/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    rubocop-cobra (0.4.4)
+    rubocop-cobra (0.4.5)
       rubocop (= 1.74.0)
       rubocop-powerhome
 

--- a/packages/rubocop-cobra/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/rubocop-cobra/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    rubocop-cobra (0.4.4)
+    rubocop-cobra (0.4.5)
       rubocop (= 1.74.0)
       rubocop-powerhome
 

--- a/packages/rubocop-cobra/lib/rubocop/cobra/version.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cobra/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Cobra
-    VERSION = "0.4.4"
+    VERSION = "0.4.5"
   end
 end

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class CommandFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class CommandFilePlacement < RuboCop::Cop::Cop
+      class CommandFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class ControllerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ControllerFilePlacement < RuboCop::Cop::Cop
+      class ControllerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
@@ -8,7 +8,7 @@ module RuboCop
 
         MSG = "External component dependencies should be declared with a version"
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class DependencyVersion < RuboCop::Cop::Cop
+      class DependencyVersion < RuboCop::Cop::Base
         extend NodePattern::Macros
 
         MSG = "External component dependencies should be declared with a version"

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
@@ -7,7 +7,7 @@ module RuboCop
         MSG = "Component Gemfile dependencies must specify " \
               "'require: nil'."
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           gem_block = component_gem_block(processed_source.ast)&.first

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class GemRequirement < RuboCop::Cop::Cop
+      class GemRequirement < RuboCop::Cop::Base
         MSG = "Component Gemfile dependencies must specify " \
               "'require: nil'."
 

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class HelperFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class HelperFilePlacement < RuboCop::Cop::Cop
+      class HelperFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/inheritance.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/inheritance.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class Inheritance < RuboCop::Cop::Cop
+      class Inheritance < RuboCop::Cop::Base
         PROTECTED_GLOBAL_CONSTANTS = %w[
           ApplicationController
           ApplicationRecord

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class JobFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class JobFilePlacement < RuboCop::Cop::Cop
+      class JobFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     end
       #   end
       #
-      class LibFilePlacement < RuboCop::Cop::Cop
+      class LibFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
@@ -28,7 +28,7 @@ module RuboCop
       class LibFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class MailerFilePlacement < RuboCop::Cop::Cop
+      class MailerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class MailerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ModelFilePlacement < RuboCop::Cop::Cop
+      class ModelFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class ModelFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
@@ -26,7 +26,7 @@ module RuboCop
       class PresenterFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           path = processed_source.file_path

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class PresenterFilePlacement < RuboCop::Cop::Cop
+      class PresenterFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
@@ -50,7 +50,7 @@ module RuboCop
           "Nest ViewComponent definitions in the parent component and resource namespace. " \
           "For example: `%<correct_path>s`"
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
           return unless path_contains_matcher?
           return if namespaced_correctly?

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
@@ -45,7 +45,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ViewComponentFilePlacement < RuboCop::Cop::Cop
+      class ViewComponentFilePlacement < RuboCop::Cop::Base
         FILE_PLACEMENT_MSG =
           "Nest ViewComponent definitions in the parent component and resource namespace. " \
           "For example: `%<correct_path>s`"

--- a/packages/rubocop-powerhome/CHANGELOG.md
+++ b/packages/rubocop-powerhome/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Fix Rubocop base class inheritance [#323](https://github.com/powerhome/power-tools/pull/323)
+
 ## [0.5.4] - 2025-03-18
 
 - Bump Rubocop version to bring in bugfixes.

--- a/packages/rubocop-powerhome/CHANGELOG.md
+++ b/packages/rubocop-powerhome/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.5.5] - 2025-04-22
+
 - Fix Rubocop base class inheritance [#323](https://github.com/powerhome/power-tools/pull/323)
 
 ## [0.5.4] - 2025-03-18

--- a/packages/rubocop-powerhome/Gemfile.lock
+++ b/packages/rubocop-powerhome/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rubocop-powerhome/gemfiles/rails_6_0.gemfile.lock
+++ b/packages/rubocop-powerhome/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rubocop-powerhome/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/rubocop-powerhome/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rubocop-powerhome/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/rubocop-powerhome/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      class ViewComponent < RuboCop::Cop::Cop
+      class ViewComponent < RuboCop::Cop::Base
         def on_class(node)
           inheritance_klass = node.node_parts[1]&.source
           return unless view_component_class?(inheritance_klass)

--- a/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
@@ -11,7 +11,7 @@ module RuboCop
         MSG = "Helpers create global view methods. Instead, use view objects to " \
               "encapsulate your display logic."
 
-        def investigate(processed_source)
+        def on_new_investigation
           return if processed_source.blank?
           return unless helper_path?
 

--- a/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
@@ -7,7 +7,7 @@ module RuboCop
       # specifically ViewComponent, create better Object Oriented design.
       # Global helper methods tightly couple templates.
       #
-      class NoHelpers < RuboCop::Cop::Cop
+      class NoHelpers < RuboCop::Cop::Base
         MSG = "Helpers create global view methods. Instead, use view objects to " \
               "encapsulate your display logic."
 

--- a/packages/rubocop-powerhome/lib/rubocop/powerhome/version.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/powerhome/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Powerhome
-    VERSION = "0.5.4"
+    VERSION = "0.5.5"
   end
 end

--- a/packages/two_percent/Gemfile.lock
+++ b/packages/two_percent/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/two_percent/gemfiles/rails_6_1.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/two_percent/gemfiles/rails_7_0.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails

--- a/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.5.4)
+    rubocop-powerhome (0.5.5)
       rubocop (= 1.74.0)
       rubocop-performance
       rubocop-rails


### PR DESCRIPTION
Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead

Docs reference: https://docs.rubocop.org/rubocop/v1_upgrade_notes.html