### PR TITLE
Remove deprecated RubocopCop::Cop

### DIFF
--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/command_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class CommandFilePlacement < RuboCop::Cop::Cop
+      class CommandFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/controller_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ControllerFilePlacement < RuboCop::Cop::Cop
+      class ControllerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/dependency_version.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class DependencyVersion < RuboCop::Cop::Cop
+      class DependencyVersion < RuboCop::Cop::Base
         extend NodePattern::Macros
 
         MSG = "External component dependencies should be declared with a version"

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/gem_requirement.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class GemRequirement < RuboCop::Cop::Cop
+      class GemRequirement < RuboCop::Cop::Base
         MSG = "Component Gemfile dependencies must specify " \
               "'require: nil'."
 

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/helper_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class HelperFilePlacement < RuboCop::Cop::Cop
+      class HelperFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/inheritance.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/inheritance.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Cobra
-      class Inheritance < RuboCop::Cop::Cop
+      class Inheritance < RuboCop::Cop::Base
         PROTECTED_GLOBAL_CONSTANTS = %w[
           ApplicationController
           ApplicationRecord

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/job_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class JobFilePlacement < RuboCop::Cop::Cop
+      class JobFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/lib_file_placement.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     end
       #   end
       #
-      class LibFilePlacement < RuboCop::Cop::Cop
+      class LibFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/mailer_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class MailerFilePlacement < RuboCop::Cop::Cop
+      class MailerFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/model_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ModelFilePlacement < RuboCop::Cop::Cop
+      class ModelFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/presenter_file_placement.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     end
       #   end
       #
-      class PresenterFilePlacement < RuboCop::Cop::Cop
+      class PresenterFilePlacement < RuboCop::Cop::Base
         include FilePlacementHelp
 
         def investigate(processed_source)

--- a/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
+++ b/packages/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
@@ -45,7 +45,7 @@ module RuboCop
       #     end
       #   end
       #
-      class ViewComponentFilePlacement < RuboCop::Cop::Cop
+      class ViewComponentFilePlacement < RuboCop::Cop::Base
         FILE_PLACEMENT_MSG =
           "Nest ViewComponent definitions in the parent component and resource namespace. " \
           "For example: `%<correct_path>s`"

--- a/packages/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      class ViewComponent < RuboCop::Cop::Cop
+      class ViewComponent < RuboCop::Cop::Base
         def on_class(node)
           inheritance_klass = node.node_parts[1]&.source
           return unless view_component_class?(inheritance_klass)

--- a/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
+++ b/packages/rubocop-powerhome/lib/rubocop/cop/style/no_helpers.rb
@@ -7,7 +7,7 @@ module RuboCop
       # specifically ViewComponent, create better Object Oriented design.
       # Global helper methods tightly couple templates.
       #
-      class NoHelpers < RuboCop::Cop::Cop
+      class NoHelpers < RuboCop::Cop::Base
         MSG = "Helpers create global view methods. Instead, use view objects to " \
               "encapsulate your display logic."
 


### PR DESCRIPTION
`Rubocop::Cop:Cop is deprecated`, use `Rubocop::Cop::Base` instead