### PR TITLE
Include id in scim attributes

### DIFF
--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -31,7 +31,7 @@ module TwoPercent
   private
 
     def scim_params
-      params.except(:controller, :action, :resource_type, :id).as_json.deep_symbolize_keys
+      params.except(:controller, :action, :resource_type).as_json.deep_symbolize_keys
     end
 
     def authenticate

--- a/packages/two_percent/spec/requests/scim_request_spec.rb
+++ b/packages/two_percent/spec/requests/scim_request_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe "Scim requests", type: :request do
     let(:valid_params) do
       {
         schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        id: "123",
         Operations: [
           {
             op: "replace",
@@ -86,6 +87,7 @@ RSpec.describe "Scim requests", type: :request do
   describe "PUT /scim/Users/:id" do
     let(:valid_params) do
       {
+        id: "123",
         userName: "test_user",
         name: {
           givenName: "Test",


### PR DESCRIPTION
Includes `id` in SCIM attributes instead of filtering it out.