### PR TITLE
Make secure by default

### DIFF
--- a/packages/two_percent/lib/two_percent/configuration.rb
+++ b/packages/two_percent/lib/two_percent/configuration.rb
@@ -30,6 +30,8 @@ module TwoPercent
   #   end
   #
   config_accessor :authenticate do
-    ->(*) { true }
+    ->(*) do
+      false
+    end
   end
 end


### PR DESCRIPTION
Force a user of the gem to configure the authentication. We should be closed by default to avoid someone accidentally forgetting to implement it.