### PR TITLE
[ORA-950] Improve params handling on Nitro queries

### DIFF
--- a/packages/data_conduit/Gemfile.lock
+++ b/packages/data_conduit/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    data_conduit (0.1.0)
+    data_conduit (0.1.1)
       rest-client (~> 2.1)
       securerandom (~> 0.2.2)
       sequel (~> 5.90.0)

--- a/packages/data_conduit/Gemfile.lock
+++ b/packages/data_conduit/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     data_conduit (0.1.1)
+      activesupport (~> 7.0)
       rest-client (~> 2.1)
       securerandom (~> 0.2.2)
       sequel (~> 5.90.0)

--- a/packages/data_conduit/bin/console
+++ b/packages/data_conduit/bin/console
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "trino/connector"
 
 require "irb"
 IRB.start(__FILE__)

--- a/packages/data_conduit/data_conduit.gemspec
+++ b/packages/data_conduit/data_conduit.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.21"
   spec.add_development_dependency "rubocop-powerhome"
   spec.add_development_dependency "webmock", "~> 3.18"
+  spec.add_dependency "activesupport", "~> 7.0"
+
   spec.add_dependency "sequel", "~> 5.90.0"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/packages/data_conduit/docs/CHANGELOG
+++ b/packages/data_conduit/docs/CHANGELOG
@@ -1,3 +1,7 @@
+## [0.1.1] - 2025-05-13
+
+- Improve config params handling
+
 ## [0.1.0] - 2025-02-24
 
 - Initial release

--- a/packages/data_conduit/lib/data_conduit.rb
+++ b/packages/data_conduit/lib/data_conduit.rb
@@ -4,6 +4,7 @@ require_relative "data_conduit/version"
 require_relative "data_conduit/data_warehouse_repository"
 require_relative "data_conduit/repository_factory"
 require_relative "data_conduit/adapters/trino_repository"
+require_relative "data_conduit/infrastructure/sequel/trino_date_literal"
 
 # Register default adapters
 DataConduit::RepositoryFactory.register(:trino, DataConduit::Adapters::TrinoRepository)

--- a/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
+++ b/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
@@ -65,10 +65,17 @@ module DataConduit
             raise ArgumentError, "Conditions must be provided as a Hash for safe query building"
           end
 
-          dataset = dataset.where(conditions)
+          converted_conditions = convert_string_keys(conditions)
+          dataset = dataset.where(converted_conditions)
         end
 
         dataset.sql
+      end
+
+      def convert_string_keys(conditions_hash)
+        conditions_hash.transform_keys do |key|
+          key.is_a?(String) || key.is_a?(Symbol) ? Sequel[key.to_sym] : key
+        end
       end
 
       def process_response(initial_response)

--- a/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
+++ b/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
@@ -87,7 +87,7 @@ module DataConduit
       end
 
       def send_query(sql)
-        base_url = server.end_with?('/') ? server.chop : server
+        base_url = server.end_with?("/") ? server.chop : server
         endpoint = "#{base_url}/v1/statement"
         JSON.parse(RestClient.post(endpoint, sql, headers).body)
       rescue JSON::ParserError => e

--- a/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
+++ b/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
@@ -87,7 +87,9 @@ module DataConduit
       end
 
       def send_query(sql)
-        JSON.parse(RestClient.post("#{server}/v1/statement", sql, headers).body)
+        base_url = server.end_with?('/') ? server.chop : server
+        endpoint = "#{base_url}/v1/statement"
+        JSON.parse(RestClient.post(endpoint, sql, headers).body)
       rescue JSON::ParserError => e
         raise DataConduit::Error, "Failed to parse JSON response: #{e.message}"
       rescue RestClient::ExceptionWithResponse => e

--- a/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
+++ b/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "sequel"
+require "date"
+
+module TrinoDateLiteral
+  def literal_other(v)
+    return "DATE '#{v.iso8601}'" if v.is_a?(Date)
+
+    super
+  end
+end
+
+Sequel::Database.extend_datasets(TrinoDateLiteral)

--- a/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
+++ b/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
@@ -2,13 +2,23 @@
 
 require "sequel"
 require "date"
+require "active_support/time"
 
 module TrinoDateLiteral
-  def literal_other(v)
-    return "DATE '#{v.iso8601}'" if v.is_a?(Date)
+  ISO_TS = "%F %T.%6N" # => "YYYY-MM-DD hh:mm:ss.ffffff"
 
-    super
+  def literal_date(v)
+    "DATE '#{v.iso8601}'"
+  end
+
+  def literal_datetime(v) = timestamp_literal(v)
+  def literal_time(v)      = timestamp_literal(v)
+
+private
+
+  def timestamp_literal(v)
+    "TIMESTAMP '#{v.strftime(ISO_TS)}'"
   end
 end
 
-Sequel::Database.extend_datasets(TrinoDateLiteral)
+Sequel::Dataset.prepend(TrinoDateLiteral)

--- a/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
+++ b/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
@@ -8,17 +8,17 @@ require "active_support/time"
 module TrinoDateLiteral
   ISO_TS = "%F %T.%6N" # => "YYYY-MM-DD hh:mm:ss.ffffff"
 
-  def literal_date(v)
-    "DATE '#{v.iso8601}'"
+  def literal_date(value)
+    "DATE '#{value.iso8601}'"
   end
 
-  def literal_datetime(v) = timestamp_literal(v)
-  def literal_time(v)      = timestamp_literal(v)
+  def literal_datetime(value) = timestamp_literal(value)
+  def literal_time(value) = timestamp_literal(value)
 
 private
 
-  def timestamp_literal(v)
-    "TIMESTAMP '#{v.strftime(ISO_TS)}'"
+  def timestamp_literal(value)
+    "TIMESTAMP '#{value.strftime(ISO_TS)}'"
   end
 end
 

--- a/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
+++ b/packages/data_conduit/lib/data_conduit/infrastructure/sequel/trino_date_literal.rb
@@ -2,6 +2,7 @@
 
 require "sequel"
 require "date"
+require "active_support"
 require "active_support/time"
 
 module TrinoDateLiteral

--- a/packages/data_conduit/lib/data_conduit/version.rb
+++ b/packages/data_conduit/lib/data_conduit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DataConduit
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/packages/data_conduit/spec/data_conduit/adapters/trino_repository_spec.rb
+++ b/packages/data_conduit/spec/data_conduit/adapters/trino_repository_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe DataConduit::Adapters::TrinoRepository do
     end
   end
 
+  describe "#build_query" do
+    context "when the condition key is a String" do
+      let(:conditions) { { "status" => "active" } }
+
+      it "converts the key and still builds the correct SQL" do
+        sql = repository.send(:build_query)
+        expect(sql).to eq("SELECT * FROM #{table_name} WHERE (status = 'active')")
+      end
+    end
+  end
+
   describe "#query" do
     let(:query_url) { "#{server}/v1/statement" }
     let(:next_url) { "#{server}/v1/statement/20240101_1" }


### PR DESCRIPTION
Improve the way DataConduit accept query conditions.
Today it requeries a Sequel obj as key: `conditions = { Sequel[:trx_month] => start_date..end_date }`
Update to support this format in Nitro: `conditions = { "trx_month" => start_date..end_date }`