### PR TITLE
[Nexus][ORA-950] Improve params handling on Nitro queries

### DIFF
--- a/packages/data_conduit/Gemfile.lock
+++ b/packages/data_conduit/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    data_conduit (0.1.1)
+    data_conduit (0.1.2)
       activesupport (~> 7.0)
       rest-client (~> 2.1)
       securerandom (~> 0.2.2)

--- a/packages/data_conduit/bin/console
+++ b/packages/data_conduit/bin/console
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "trino/connector"
 
 require "irb"
 IRB.start(__FILE__)

--- a/packages/data_conduit/docs/CHANGELOG
+++ b/packages/data_conduit/docs/CHANGELOG
@@ -1,6 +1,6 @@
 ## [0.1.2] - 2025-05-30
 
-- Improve conditions key handling for the TrinoAdapter
+- Improve conditions key handling for the TrinoAdapter [#345](https://github.com/powerhome/power-tools/pull/345)
 
 ## [0.1.1] - 2025-05-13
 

--- a/packages/data_conduit/docs/CHANGELOG
+++ b/packages/data_conduit/docs/CHANGELOG
@@ -1,3 +1,7 @@
+## [0.1.2] - 2025-05-30
+
+- Improve conditions key handling for the TrinoAdapter
+
 ## [0.1.1] - 2025-05-13
 
 - Improve config params handling

--- a/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
+++ b/packages/data_conduit/lib/data_conduit/adapters/trino_repository.rb
@@ -65,10 +65,17 @@ module DataConduit
             raise ArgumentError, "Conditions must be provided as a Hash for safe query building"
           end
 
-          dataset = dataset.where(conditions)
+          converted_conditions = convert_string_keys(conditions)
+          dataset = dataset.where(converted_conditions)
         end
 
         dataset.sql
+      end
+
+      def convert_string_keys(conditions_hash)
+        conditions_hash.transform_keys do |key|
+          key.is_a?(String) || key.is_a?(Symbol) ? Sequel[key.to_sym] : key
+        end
       end
 
       def process_response(initial_response)

--- a/packages/data_conduit/lib/data_conduit/version.rb
+++ b/packages/data_conduit/lib/data_conduit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DataConduit
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/packages/data_conduit/spec/data_conduit/adapters/trino_repository_spec.rb
+++ b/packages/data_conduit/spec/data_conduit/adapters/trino_repository_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe DataConduit::Adapters::TrinoRepository do
     end
   end
 
+  describe "#build_query" do
+    context "when the condition key is a String" do
+      let(:conditions) { { "status" => "active" } }
+
+      it "converts the key and still builds the correct SQL" do
+        sql = repository.send(:build_query)
+        expect(sql).to eq("SELECT * FROM #{table_name} WHERE (status = 'active')")
+      end
+    end
+  end
+
   describe "#query" do
     let(:query_url) { "#{server}/v1/statement" }
     let(:next_url) { "#{server}/v1/statement/20240101_1" }


### PR DESCRIPTION
Improve the way TrinoAdapter accepts query condition keys.
Today it requires a Sequel obj as key: conditions = { Sequel[:trx_month] => start_date..end_date }
Update to support string keys in Nitro: conditions = { "trx_month" => start_date..end_date }

[Runway story](https://runway.powerhrg.com/backlog_items/ORA-950)