### PR TITLE
Update two percent with newest aether observatory

### DIFF
--- a/packages/two_percent/two_percent.gemspec
+++ b/packages/two_percent/two_percent.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "aether_observatory", ">= 1.0"
+  spec.add_dependency "aether_observatory", git: "https://github.com/powerhome/power-tools", ref: "35ccf314080f63b0dd7f4091aa34318693573525"
   spec.add_dependency "rails", ">= 6.1"
 end


### PR DESCRIPTION
This PR sets two-percent to use the latest AetherObservatory. We're pointing to the ref for testing but when v1.0.1 is released we will point to that gem instead. 