### PR TITLE
[GOG-1066] Not allow Edgestitch overwrites the structure.sql

### DIFF
--- a/packages/edgestitch/lib/edgestitch/stitcher.rb
+++ b/packages/edgestitch/lib/edgestitch/stitcher.rb
@@ -19,7 +19,7 @@ module Edgestitch
     end
 
     def self.to_file(file, *engines)
-      File.write(file, new(engines).render)
+      File.write(file, new(engines).render) unless File.exist?(file)
     end
   end
 end

--- a/packages/edgestitch/spec/edgestitch/tasks_spec.rb
+++ b/packages/edgestitch/spec/edgestitch/tasks_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe Edgestitch::Tasks do
       rake_execute "db:stitch"
     end
 
+    it "does not save the structure.sql when the file exists" do
+      structure_sql_file = Rails.root.join("db", "structure.sql").to_s
+
+      allow(File).to receive(:exist?).with(structure_sql_file).and_return(true)
+
+      expect(Edgestitch::Stitcher).to(
+        receive(:to_file) do |file, *engines|
+          expect(file).to eq structure_sql_file
+          expect(File).not_to receive(:write)
+        end
+      )
+
+      rake_execute "db:stitch"
+    end
+
     describe "rails enhancing" do
       it "creates the structure.sql before loading a schema" do
         execution = dry_run("db:schema:load")

--- a/packages/edgestitch/spec/edgestitch/tasks_spec.rb
+++ b/packages/edgestitch/spec/edgestitch/tasks_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Edgestitch::Tasks do
       allow(File).to receive(:exist?).with(structure_sql_file).and_return(true)
 
       expect(Edgestitch::Stitcher).to(
-        receive(:to_file) do |file, *engines|
+        receive(:to_file) do |file, *_engines|
           expect(file).to eq structure_sql_file
           expect(File).not_to receive(:write)
         end


### PR DESCRIPTION
The idea is to prevent Edgestitch from overwriting the `structure.sql` file during test setup when the file already exists. This change is necessary to address persistent CI failures caused by concurrent schema regeneration while implementing [parallel_test](https://github.com/grosser/parallel_tests) in [nitro-web-pr49766](https://github.com/powerhome/nitro-web/pull/49766).

In the test setup, the `structure.sql` file is generated upfront using `db:prepare db:migration` before any parallel jobs run. Test databases are then created in parallel, with each process loading the schema from the pre-generated structure.sql. Previously, Edgestitch would regenerate `structure.sql` every time `db:schema:load` was invoked; often, not all migrations were present. This led to a corrupted or partial structure.sql, breaking parallel test runs.