### PR TITLE
[HFH-4341] Update rails min to 7.0 and remove nokogiri dependency in rabbet for CVE

### DIFF
--- a/packages/rabbet/Gemfile.lock
+++ b/packages/rabbet/Gemfile.lock
@@ -13,8 +13,7 @@ PATH
   specs:
     rabbet (0.0.3)
       cygnet (= 0.0.1)
-      nokogiri (= 1.17.2)
-      rails (>= 6.0)
+      rails (>= 7.0)
       sassc-rails (= 2.1.2)
 
 GEM

--- a/packages/rabbet/docs/CHANGELOG.md
+++ b/packages/rabbet/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Drop support for Ruby < 3.3 and Rails < 7.1 [#396](https://github.com/powerhome/power-tools/pull/396)
 - Update yard to 0.9.38 to address [Cross-site Scripting vulnerability](https://github.com/powerhome/power-tools/security/dependabot/544) [#394](https://github.com/powerhome/power-tools/pull/394)
 - Update rainbow to v3.x [#372](https://github.com/powerhome/power-tools/pull/372)
-- Update minimum Rails support to drop nokogiri dependency [#408](https://github.com/powerhome/power-tools/pull/408)
+- Update minimum Rails support to 7.0 to drop nokogiri dependency [#408](https://github.com/powerhome/power-tools/pull/408)
 
 ## [0.0.3] - 2022-12-22
 

--- a/packages/rabbet/docs/CHANGELOG.md
+++ b/packages/rabbet/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Drop support for Ruby < 3.3 and Rails < 7.1 [#396](https://github.com/powerhome/power-tools/pull/396)
 - Update yard to 0.9.38 to address [Cross-site Scripting vulnerability](https://github.com/powerhome/power-tools/security/dependabot/544) [#394](https://github.com/powerhome/power-tools/pull/394)
 - Update rainbow to v3.x [#372](https://github.com/powerhome/power-tools/pull/372)
+- Update minimum Rails support to drop nokogiri dependency [#408](https://github.com/powerhome/power-tools/pull/408)
 
 ## [0.0.3] - 2022-12-22
 

--- a/packages/rabbet/rabbet.gemspec
+++ b/packages/rabbet/rabbet.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "cygnet", "0.0.1"
-  s.add_dependency "nokogiri", "1.17.2" # can be removed after we remove support for Rails 6.0.1
-  s.add_dependency "rails", ">= 6.0"
+  s.add_dependency "rails", ">= 7.0"
   s.add_dependency "sassc-rails", "2.1.2"
 
   s.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
https://github.com/powerhome/power-tools/security/dependabot/651