### PR TITLE
Fix remaining lumberaxe appraisal lockfile mismatches

### DIFF
--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    lumberaxe (0.2.0)
+    lumberaxe (0.2.5)
       activesupport (>= 6.0.6.1, <= 8.0.5)
       lograge (= 0.10.0)
 

--- a/packages/lumberaxe/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_2.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    lumberaxe (0.2.0)
+    lumberaxe (0.2.5)
       activesupport (>= 6.0.6.1, <= 8.0.5)
       lograge (= 0.10.0)
 

--- a/packages/lumberaxe/gemfiles/rails_8_0.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.6.0)
+    rubocop-powerhome (0.6.1)
       rubocop (= 1.82.1)
       rubocop-performance
       rubocop-rails
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    lumberaxe (0.2.0)
+    lumberaxe (0.2.5)
       activesupport (>= 6.0.6.1, <= 8.0.5)
       lograge (= 0.10.0)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock` to match the current local `lumberaxe` gem version (`0.2.5`)
- update `packages/lumberaxe/gemfiles/rails_7_2.gemfile.lock` to match the current local `lumberaxe` gem version (`0.2.5`)
- update `packages/lumberaxe/gemfiles/rails_8_0.gemfile.lock` to match current path gem versions:
  - `lumberaxe (0.2.5)`
  - `rubocop-powerhome (0.6.1)`

## Why
Recent CI failures for the `lumberaxe` workflow were due to Bundler frozen lockfile checks failing with:

- `The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set`

These changes align appraisal lockfiles with the committed path gemspec versions so bundle install in CI no longer fails in frozen mode.

## Validation
- inspected failing GitHub Actions logs for workflow `lumberaxe`
- confirmed lockfile diffs are limited to the stale path gem version entries
- local appraisal execution could not be run in this environment because Ruby/Bundler are unavailable (`ruby: command not found`, `bundle: command not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cee254b0-e5ee-47f4-b950-190a35eaa44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cee254b0-e5ee-47f4-b950-190a35eaa44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

