### PR TITLE
[HFH-4410] Resolve remaining lumberaxe workflow failures

### DIFF
--- a/packages/lumberaxe/Appraisals
+++ b/packages/lumberaxe/Appraisals
@@ -3,7 +3,7 @@
 appraise "rails-7-1" do
   gem "rails", "7.1.3.2"
   gem "rspec-rails", "~> 7.1.1"
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", "~> 1.7.3"
 end
 
 appraise "rails-7-2" do

--- a/packages/lumberaxe/Appraisals
+++ b/packages/lumberaxe/Appraisals
@@ -3,6 +3,7 @@
 appraise "rails-7-1" do
   gem "rails", "7.1.3.2"
   gem "rspec-rails", "~> 7.1.1"
+  gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails-7-2" do

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile
@@ -18,7 +18,7 @@ gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 7.1.1"
 gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "simplecov", "0.15.1"
-gem "sqlite3", "~> 2.9"
+gem "sqlite3", "~> 1.4"
 gem "test-unit", "3.1.5"
 gem "yard", "0.9.38"
 

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile
@@ -18,7 +18,7 @@ gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 7.1.1"
 gem "rubocop-powerhome", path: "../../rubocop-powerhome"
 gem "simplecov", "0.15.1"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 1.7.3"
 gem "test-unit", "3.1.5"
 gem "yard", "0.9.38"
 

--- a/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock
@@ -299,8 +299,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sqlite3 (2.9.2-arm64-darwin)
-    sqlite3 (2.9.2-x86_64-linux-gnu)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stringio (3.2.0)
     test-unit (3.1.5)
       power_assert
@@ -345,7 +345,7 @@ DEPENDENCIES
   rspec-rails (~> 7.1.1)
   rubocop-powerhome!
   simplecov (= 0.15.1)
-  sqlite3 (~> 2.9)
+  sqlite3 (~> 1.7.3)
   test-unit (= 3.1.5)
   yard (= 0.9.38)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Rails 7.1-specific `sqlite3` pin in `packages/lumberaxe/Appraisals`
- align `packages/lumberaxe/gemfiles/rails_7_1.gemfile` to the same `sqlite3` requirement
- update `packages/lumberaxe/gemfiles/rails_7_1.gemfile.lock` so frozen bundler mode remains consistent
- restore trailing newline in `Appraisals` to satisfy RuboCop EOF formatting checks

## Root cause addressed
The `lumberaxe` workflow had two remaining failures in the Rails 7.1 matrix:
1. ActiveRecord 7.1 adapter load error due to incompatible `sqlite3` major version
2. Frozen-lockfile mismatch (`bundle` exit code 16) after adjusting Gemfile constraints

## Validation
- verified `lumberaxe` workflow now passes on this branch:
  - run: `25569259058`
  - `rails_7_1` matrix job: success
  - `rails_7_2` matrix job: success
  - license compliance and aggregate jobs: success
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-340b4811-3102-47eb-abd6-c9080ec51cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-340b4811-3102-47eb-abd6-c9080ec51cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

