### PR TITLE
Fix dep_shield workflow failures after nitro_config bump

### DIFF
--- a/packages/dep_shield/Appraisals
+++ b/packages/dep_shield/Appraisals
@@ -15,5 +15,3 @@ end
 appraise "rails-8-1" do
   gem "rails", "8.1.3"
 end
-
-

--- a/packages/dep_shield/Gemfile.lock
+++ b/packages/dep_shield/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../nitro_config
   specs:
-    nitro_config (0.2.0)
+    nitro_config (0.3.0)
       activesupport (>= 7.1, < 8.2)
 
 PATH

--- a/packages/dep_shield/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../nitro_config
   specs:
-    nitro_config (0.2.0)
+    nitro_config (0.3.0)
       activesupport (>= 7.1, < 8.2)
 
 PATH

--- a/packages/dep_shield/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../nitro_config
   specs:
-    nitro_config (0.2.0)
+    nitro_config (0.3.0)
       activesupport (>= 7.1, < 8.2)
 
 PATH

--- a/packages/dep_shield/gemfiles/rails_8_0.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../nitro_config
   specs:
-    nitro_config (0.2.0)
+    nitro_config (0.3.0)
       activesupport (>= 7.1, < 8.2)
 
 PATH

--- a/packages/dep_shield/gemfiles/rails_8_1.gemfile.lock
+++ b/packages/dep_shield/gemfiles/rails_8_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../nitro_config
   specs:
-    nitro_config (0.2.0)
+    nitro_config (0.3.0)
       activesupport (>= 7.1, < 8.2)
 
 PATH


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `packages/dep_shield/Gemfile.lock` to reference `nitro_config (0.3.0)` in the path spec
- update dep_shield appraisal lockfiles (`rails_7_1`, `rails_7_2`, `rails_8_0`, `rails_8_1`) to the same path gem version
- remove extra trailing blank lines in `packages/dep_shield/Appraisals` to satisfy RuboCop (`Layout/TrailingEmptyLines`)

## Validation
- inspected failing `dep_shield` GitHub Actions logs and confirmed initial frozen Bundler error was due to stale path gem lock entries
- after lockfile update, reran CI and identified remaining RuboCop violation in `Appraisals`
- pushed formatting fix and confirmed the latest `dep_shield` run is green: https://github.com/powerhome/power-tools/actions/runs/25699217798
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b1f84ff-438c-419b-8e49-0f7445175ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b1f84ff-438c-419b-8e49-0f7445175ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

