### PR TITLE
[GOG-1783] Add npm_token secret to eslint-config workflow

### DIFF
--- a/.github/workflows/eslint-config.yml
+++ b/.github/workflows/eslint-config.yml
@@ -10,4 +10,5 @@ jobs:
       package: ${{ github.workflow }}
       node: '["20", "22"]'
       workdir: "packages/${{ github.workflow }}"
-    secrets: inherit
+    secrets:
+      npm_token: ${{ secrets.POWERHOME_NPM_REGISTRY_PASSWORD }}


### PR DESCRIPTION
We need to explicitly define this secret so this Action can authenticate against our internal NPM registry.

This can be seen working in action in [this run](https://github.com/powerhome/power-tools/actions/runs/25754515055/job/75639290672?pr=414), which succeeded.

This should be merged after https://github.com/powerhome/github-actions-workflows/pull/40, which changes the upstream Action that this repo pulls in.