### PR TITLE
[HFH-4436] SPIKE - Graph-aware export

### DIFF
--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -33,7 +33,8 @@ module DataTaster
       list: Array.wrap(args[:list] || Rails.root.glob("**/data_taster_export_tables.yml")),
       source_client: args[:source_client] || raise(ArgumentError, "DataTaster.config missing source_client"),
       working_client: args[:working_client],
-      include_insert: args[:include_insert] || false
+      include_insert: args[:include_insert] || false,
+      filename: args[:filename] || nil
     )
   end
 
@@ -73,5 +74,5 @@ module DataTaster
     end
   end
 
-  Config = Struct.new(:months, :list, :source_client, :working_client, :include_insert)
+  Config = Struct.new(:months, :list, :source_client, :working_client, :include_insert, :filename)
 end

--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -21,7 +21,7 @@ module DataTaster
   def self.logger
     @logger ||= Logger.new($stdout)
   end
-  
+
   def self.reset!
     @config = nil
     @confection = nil

--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -57,6 +57,13 @@ module DataTaster
     DataTaster::SampleToSql.new.serve!
   end
 
+  def self.target_database
+    # when working_client is not set it means all operations should be performed on the source_client.
+    # Be careful with this, as this will mutate the source_client database.
+    client = config.working_client || config.source_client
+    client.query_options[:database]
+  end
+
   def self.safe_execute(sql, client = DataTaster.config.working_client)
     foreign_key_check = client.query("SELECT @@FOREIGN_KEY_CHECKS").first["@@FOREIGN_KEY_CHECKS"]
 

--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -28,11 +28,9 @@ module DataTaster
   end
 
   def self.config(**args)
-    exports_list = Array.wrap(args[:list] || Rails.root.glob("**/data_taster_export_tables.yml"))
-
     @config ||= Config.new(
       months: args[:months] || nil,
-      list: exports_list,
+      list: Array.wrap(args[:list] || Rails.root.glob("**/data_taster_export_tables.yml")),
       source_client: args[:source_client] || raise(ArgumentError, "DataTaster.config missing source_client"),
       working_client: args[:working_client],
       include_insert: args[:include_insert] || false

--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -8,7 +8,9 @@ module DataTaster
   autoload :Detergent, "data_taster/detergent"
   autoload :Helper, "data_taster/helper"
   autoload :Sample, "data_taster/sample"
+  autoload :SampleToSql, "data_taster/sample_to_sql"
   autoload :Sanitizer, "data_taster/sanitizer"
+  autoload :SqlLiteral, "data_taster/sql_literal"
 
   SKIP_CODE = "skip_processing"
 
@@ -19,14 +21,21 @@ module DataTaster
   def self.logger
     @logger ||= Logger.new($stdout)
   end
+  
+  def self.reset!
+    @config = nil
+    @confection = nil
+  end
 
   def self.config(**args)
+    exports_list = Array.wrap(args[:list] || Rails.root.glob("**/data_taster_export_tables.yml"))
+
     @config ||= Config.new(
-      args[:months],
-      Array.wrap(args[:list] || Rails.root.glob("**/data_taster_export_tables.yml")),
-      args[:source_client] || raise(ArgumentError, "DataTaster.config missing source_client"),
-      args[:working_client] || raise(ArgumentError, "DataTaster.config missing working_client"),
-      args[:include_insert] || false
+      months: args[:months] || nil,
+      list: exports_list,
+      source_client: args[:source_client] || raise(ArgumentError, "DataTaster.config missing source_client"),
+      working_client: args[:working_client],
+      include_insert: args[:include_insert] || false
     )
   end
 
@@ -42,6 +51,10 @@ module DataTaster
       .each do |table_name|
         DataTaster::Sample.new(table_name).serve!
       end
+  end
+
+  def self.sample_to_sql_file!
+    DataTaster::SampleToSql.new.serve!
   end
 
   def self.safe_execute(sql, client = DataTaster.config.working_client)

--- a/packages/data_taster/lib/data_taster.rb
+++ b/packages/data_taster/lib/data_taster.rb
@@ -5,6 +5,7 @@ require "logger"
 module DataTaster
   autoload :Collection, "data_taster/collection"
   autoload :Confection, "data_taster/confection"
+  autoload :ExportGraphCompiler, "data_taster/export_graph_compiler"
   autoload :Detergent, "data_taster/detergent"
   autoload :Helper, "data_taster/helper"
   autoload :Sample, "data_taster/sample"
@@ -34,7 +35,8 @@ module DataTaster
       source_client: args[:source_client] || raise(ArgumentError, "DataTaster.config missing source_client"),
       working_client: args[:working_client],
       include_insert: args[:include_insert] || false,
-      filename: args[:filename] || nil
+      filename: args[:filename] || nil,
+      graph_anchor_allowlist: args[:graph_anchor_allowlist]
     )
   end
 
@@ -74,5 +76,14 @@ module DataTaster
     end
   end
 
-  Config = Struct.new(:months, :list, :source_client, :working_client, :include_insert, :filename)
+  Config = Struct.new(
+    :months,
+    :list,
+    :source_client,
+    :working_client,
+    :include_insert,
+    :filename,
+    :graph_anchor_allowlist,
+    keyword_init: true
+  )
 end

--- a/packages/data_taster/lib/data_taster/collection.rb
+++ b/packages/data_taster/lib/data_taster/collection.rb
@@ -75,7 +75,7 @@ module DataTaster
     end
 
     def working_db
-      @working_db ||= DataTaster.config.working_client.query_options[:database]
+      @working_db ||= DataTaster.target_database
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/collection.rb
+++ b/packages/data_taster/lib/data_taster/collection.rb
@@ -26,6 +26,13 @@ module DataTaster
       end
     end
 
+    def export_select_sql
+      <<-SQL.squish
+        SELECT * FROM #{source_db}.#{table_name}
+        WHERE #{where_clause}
+      SQL
+    end
+
   private
 
     attr_reader :table_name, :ingredients, :include_insert

--- a/packages/data_taster/lib/data_taster/confection.rb
+++ b/packages/data_taster/lib/data_taster/confection.rb
@@ -24,7 +24,10 @@ module DataTaster
       flavored_erb = erb.def_class(DataTaster::Flavors, "render()")
       erb_result = flavored_erb.new.render
 
-      YAML.safe_load(erb_result.gsub(/((.|\n)*---)/, "\n---")) || {}
+      hash = YAML.safe_load(erb_result.gsub(/((.|\n)*---)/, "\n---")) || {}
+      hash.transform_keys!(&:to_s)
+      ExportGraphCompiler.merge_into!(hash)
+      hash
     end
 
   private

--- a/packages/data_taster/lib/data_taster/detergent.rb
+++ b/packages/data_taster/lib/data_taster/detergent.rb
@@ -59,7 +59,7 @@ module DataTaster
 
     def sql_for_uncast_value
       <<-SQL.squish
-        UPDATE #{working_db}.#{table_name}
+        UPDATE #{target_database}.#{table_name}
         SET #{column_name} = #{value}
         WHERE #{column_name} IS NOT NULL
         AND #{column_name} <> #{value}
@@ -68,7 +68,7 @@ module DataTaster
 
     def sql_for_date_value
       <<-SQL.squish
-        UPDATE #{working_db}.#{table_name}
+        UPDATE #{target_database}.#{table_name}
         SET #{column_name} = '#{value}'
         WHERE #{column_name} IS NOT NULL
       SQL
@@ -76,7 +76,7 @@ module DataTaster
 
     def sql_for_nil_value
       <<-SQL.squish
-        UPDATE #{working_db}.#{table_name}
+        UPDATE #{target_database}.#{table_name}
         SET #{column_name} = NULL
         WHERE #{column_name} IS NOT NULL
       SQL
@@ -84,14 +84,14 @@ module DataTaster
 
     def sql_for_cast_value
       <<-SQL.squish
-        UPDATE #{working_db}.#{table_name}
+        UPDATE #{target_database}.#{table_name}
         SET #{column_name} = '#{value}'
         WHERE #{column_name} IS NOT NULL
         AND #{column_name} <> ''
       SQL
     end
 
-    def working_db
+    def target_database
       DataTaster.config.working_client.query_options[:database]
     end
   end

--- a/packages/data_taster/lib/data_taster/detergent.rb
+++ b/packages/data_taster/lib/data_taster/detergent.rb
@@ -92,7 +92,7 @@ module DataTaster
     end
 
     def target_database
-      DataTaster.config.working_client.query_options[:database]
+      DataTaster.target_database
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/export_graph_compiler.rb
+++ b/packages/data_taster/lib/data_taster/export_graph_compiler.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists
+module DataTaster
+  # Expands top-level +data_taster_export_graphs+ in export YAML into flat
+  # +table_name => WHERE fragment+ entries for {Collection}. Removes the reserved
+  # key. Explicit table keys in the file win over generated ones.
+  class ExportGraphCompiler
+    RESERVED_KEY = "data_taster_export_graphs"
+    DEFAULT_ORDER = "id DESC"
+    DEFAULT_LIMIT = 200
+
+    class Error < StandardError; end
+    class UnsupportedAssociation < Error; end
+
+    class << self
+      def merge_into!(hash)
+        graphs = hash.delete(RESERVED_KEY)
+        return hash unless graphs.is_a?(Hash)
+
+        compiled = {}
+        graphs.each_value do |spec|
+          compile_named_graph!(compiled, spec)
+        end
+
+        hash.replace(compiled.merge(hash))
+      end
+
+    private
+
+      def compile_named_graph!(tables, spec)
+        spec = stringify_keys(spec)
+        anchor = spec["anchor"]
+        raise Error, "data_taster graph missing anchor" unless anchor.is_a?(Hash)
+
+        anchor = stringify_keys(anchor)
+        model_name = anchor.fetch("model")
+        anchor_class = constantize_anchor(model_name)
+        where_sql = anchor.fetch("where_sql")
+        order = normalized_order(anchor["order"])
+        limit = limit_value(anchor["limit"])
+
+        includes = Array(spec["includes"])
+        raise Error, "data_taster graph includes must be a non-empty list" if includes.empty?
+
+        tables[anchor_class.table_name] =
+          anchor_owning_rows_clause(anchor_class, where_sql, order, limit)
+
+        includes.each do |name|
+          add_include!(tables, anchor_class, where_sql, order, limit, name.to_sym)
+        end
+      end
+
+      def normalized_order(value)
+        s = value.to_s.strip
+        s.empty? ? DEFAULT_ORDER : s
+      end
+
+      def add_include!(tables, anchor_class, where_sql, order, limit, assoc_name)
+        reflection = anchor_class.reflect_on_association(assoc_name)
+        raise Error, "Unknown association #{assoc_name.inspect} on #{anchor_class.name}" unless reflection
+
+        if reflection.polymorphic?
+          log_skip_association("polymorphic", anchor_class.name, assoc_name)
+          return
+        end
+
+        if %i[has_many has_one].include?(reflection.macro) && reflection.options[:as].present?
+          log_skip_association("polymorphic-inverse", anchor_class.name, assoc_name)
+          return
+        end
+
+        case reflection.macro
+        when :has_many, :has_one
+          if reflection.options[:through]
+            compile_has_many_through!(tables, anchor_class, reflection, where_sql, order, limit)
+          else
+            compile_has_many_or_has_one!(tables, reflection, where_sql, order, limit)
+          end
+        when :belongs_to
+          compile_belongs_to!(tables, reflection, anchor_class, where_sql, order, limit)
+        else
+          msg = "Unsupported macro #{reflection.macro} for #{assoc_name} on #{anchor_class.name}"
+          raise UnsupportedAssociation, msg
+        end
+      end
+
+      def log_skip_association(kind, model_name, assoc_name)
+        DataTaster.logger.info(
+          "[DataTaster::ExportGraphCompiler] Skipping #{kind} association #{assoc_name.inspect} on #{model_name}"
+        )
+      end
+
+      def anchor_owning_rows_clause(anchor_class, where_sql, order, limit)
+        anchor_table = anchor_class.table_name
+        anchor_pk = anchor_class.primary_key.to_s
+        if anchor_pk.include?(",")
+          raise UnsupportedAssociation, "Composite primary key not supported for #{anchor_class.name}"
+        end
+
+        inner = anchor_inner_select(anchor_table, anchor_pk, where_sql, order, limit)
+        subquery = wrapped_anchor_column_subquery(inner, anchor_pk, "data_taster_anchor_ids")
+        "`#{quote_ident_part(anchor_pk)}` IN (#{subquery})"
+      end
+
+      def compile_has_many_or_has_one!(tables, reflection, where_sql, order, limit)
+        child = reflection.klass
+        fk = reflection.foreign_key.to_s
+        anchor_table = reflection.active_record.table_name
+        anchor_pk = reflection.active_record.primary_key.to_s
+        if anchor_pk.include?(",")
+          raise UnsupportedAssociation, "Composite primary key not supported for #{reflection.active_record.name}"
+        end
+
+        inner = anchor_inner_select(anchor_table, anchor_pk, where_sql, order, limit)
+        anchor_sq = wrapped_anchor_column_subquery(inner, anchor_pk, "data_taster_anchor_ids")
+        tables[child.table_name] = "`#{quote_ident_part(fk)}` IN (#{anchor_sq})"
+      end
+
+      def compile_belongs_to!(tables, reflection, anchor_class, where_sql, order, limit)
+        parent_table = reflection.klass.table_name
+        parent_pk = association_primary_key_column(reflection)
+        fk = reflection.foreign_key.to_s
+        anchor_table = anchor_class.table_name
+
+        lim = limit_sql_fragment(limit)
+        inner = <<~SQL.squish
+          SELECT `#{quote_ident_part(fk)}` FROM #{source_database_name}.`#{quote_ident_part(anchor_table)}`
+          WHERE (#{where_sql}) ORDER BY #{order} #{lim}
+        SQL
+        wrapped = wrapped_anchor_column_subquery(inner, fk, "data_taster_anchor_fks")
+        sql = "`#{quote_ident_part(parent_pk)}` IN (#{wrapped})"
+        tables[parent_table] = sql
+      end
+
+      def compile_has_many_through!(tables, anchor_class, reflection, where_sql, order, limit)
+        parts = through_association_parts(anchor_class, reflection)
+        inner = anchor_inner_select(
+          parts.fetch(:anchor_table),
+          parts.fetch(:anchor_pk),
+          where_sql,
+          order,
+          limit
+        )
+        anchor_sq = wrapped_anchor_column_subquery(inner, parts.fetch(:anchor_pk), "data_taster_anchor_ids")
+        join_fk = parts.fetch(:join_fk_to_anchor)
+        join_table = parts.fetch(:join_table)
+        tables[join_table] = "`#{quote_ident_part(join_fk)}` IN (#{anchor_sq})"
+
+        target_table = parts.fetch(:target_table)
+        target_pk = parts.fetch(:target_pk)
+        target_fk = parts.fetch(:target_fk)
+        tables[target_table] = <<~SQL.squish
+          `#{quote_ident_part(target_pk)}` IN (
+            SELECT `#{quote_ident_part(target_fk)}` FROM #{source_database_name}.`#{quote_ident_part(join_table)}`
+            WHERE `#{quote_ident_part(join_fk)}` IN (#{anchor_sq})
+          )
+        SQL
+      end
+
+      def through_association_parts(anchor_class, reflection)
+        through = reflection.through_reflection
+        join_table = through.klass.table_name
+        join_fk_to_anchor = through.foreign_key.to_s
+
+        source = reflection.source_reflection
+        if source.options[:through]
+          raise UnsupportedAssociation,
+                "Multi-level has_many :through is not supported (#{reflection.name} on #{anchor_class.name})"
+        end
+
+        target_table = source.klass.table_name
+        target_pk = source.klass.primary_key.to_s
+        target_fk = source.foreign_key.to_s
+        if target_pk.blank? || target_pk.include?(",")
+          raise UnsupportedAssociation, "Composite primary key not supported for #{source.klass.name}"
+        end
+
+        {
+          anchor_table: anchor_class.table_name,
+          anchor_pk: anchor_class.primary_key.to_s,
+          join_table: join_table,
+          join_fk_to_anchor: join_fk_to_anchor,
+          target_table: target_table,
+          target_pk: target_pk,
+          target_fk: target_fk,
+        }
+      end
+
+      def anchor_inner_select(anchor_table, anchor_pk, where_sql, order, limit)
+        lim = limit_sql_fragment(limit)
+        <<~SQL.squish
+          SELECT `#{quote_ident_part(anchor_pk)}` FROM #{source_database_name}.`#{quote_ident_part(anchor_table)}`
+          WHERE (#{where_sql}) ORDER BY #{order} #{lim}
+        SQL
+      end
+
+      # MySQL rejects +IN (SELECT ... ORDER BY ... LIMIT ...)+ on many versions; wrapping the inner
+      # select as a derived table is the standard workaround.
+      def wrapped_anchor_column_subquery(inner_select_sql, column_name, derived_table_alias)
+        qc = quote_ident_part(column_name)
+        qa = quote_ident_part(derived_table_alias)
+        <<~SQL.squish
+          SELECT `#{qc}` FROM (#{inner_select_sql.strip}) AS `#{qa}`
+        SQL
+      end
+
+      def limit_value(raw)
+        return DEFAULT_LIMIT if raw.nil?
+
+        raw.to_i
+      end
+
+      def limit_sql_fragment(limit)
+        return "" if limit == 0
+
+        "LIMIT #{Integer(limit)}"
+      end
+
+      def association_primary_key_column(reflection)
+        pk = reflection.association_primary_key
+        pk = pk.first if pk.is_a?(Array)
+        pk = pk.to_s
+        raise UnsupportedAssociation, "Composite association primary key not supported" if pk.include?(",") || pk.blank?
+
+        pk
+      end
+
+      def constantize_anchor(model_name)
+        class_name = model_name.to_s
+        unless anchor_model_allowed?(class_name)
+          raise Error, "Anchor model not allowed by graph_anchor_allowlist: #{class_name.inspect}"
+        end
+
+        class_name.constantize
+      end
+
+      def anchor_model_allowed?(class_name)
+        list = DataTaster.config.graph_anchor_allowlist
+        return true if list.nil?
+
+        Array(list).any? { |prefix| class_name.start_with?(prefix.to_s) }
+      end
+
+      def stringify_keys(obj)
+        return obj unless obj.is_a?(Hash)
+
+        obj.each_with_object({}) { |(k, v), h| h[k.to_s] = v }
+      end
+
+      def quote_ident_part(str)
+        str.to_s.gsub("`", "``")
+      end
+
+      def source_database_name
+        db = DataTaster.config.source_client&.query_options&.[](:database)
+        if db.nil? || db.to_s.empty?
+          raise Error,
+                "Cannot resolve source database for export graphs; set DataTaster.config " \
+                "with source_client.query_options[:database]"
+        end
+
+        db.to_s
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ClassLength, Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists

--- a/packages/data_taster/lib/data_taster/sample.rb
+++ b/packages/data_taster/lib/data_taster/sample.rb
@@ -39,7 +39,7 @@ module DataTaster
     end
 
     def working_db
-      @working_db ||= DataTaster.config.working_client.query_options[:database]
+      @working_db ||= DataTaster.target_database
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -10,7 +10,8 @@ module DataTaster
     end
 
     def serve!
-      File.open(temp_file_path, "w") do |io|
+      path = temp_file_path
+      File.open(path, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
           .confection.keys
@@ -19,7 +20,7 @@ module DataTaster
           end
         io.puts "SET FOREIGN_KEY_CHECKS=1;"
       end
-      temp_file_path
+      path
     end
 
   private
@@ -51,7 +52,6 @@ module DataTaster
       return if columns.empty?
 
       process_export_in_batches(io, columns, result, safe_db_name, safe_table_name)
-      append_sanitizer_statements(io, table_name, payload[:sanitize])
     end
 
     def process_export_in_batches(io, columns, result, safe_db_name, safe_table_name)
@@ -63,6 +63,7 @@ module DataTaster
           batch.clear
         end
       end
+      write_export_batch(io, columns, batch, safe_db_name, safe_table_name) if batch.any?
     end
 
     def sanitize_data(io, table_name, sanitize)

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
 module DataTaster
   # Selects and sanitizes tables from the source_db to write to a SQL file on disk.
   class SampleToSql
@@ -13,7 +11,6 @@ module DataTaster
 
     def serve!
       path = temp_file_path
-      FileUtils.mkdir_p(File.dirname(path))
       File.open(path, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
@@ -37,9 +34,10 @@ module DataTaster
       collection = DataTaster::Collection.new(table_name)
       payload = collection.assemble
 
-      # Any table that does not return SQL is considered deprecated and we should fully skip it
+      # Deprecated tables (skip in YAML): emit DROP for the restore target only — never execute
+      # DDL against the source. Live sampling uses +working_client+ via +safe_execute+.
       if payload.empty? && DataTaster.config.include_insert
-        DataTaster.safe_execute("DROP TABLE IF EXISTS #{table_name}", source_client)
+        io.puts "DROP TABLE IF EXISTS #{safe_db_name}.#{safe_table_name};"
         return
       end
 

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -10,7 +10,7 @@ module DataTaster
     end
 
     def serve!
-      Rails.logger.info("Writing SQL file to #{DataTaster.config.filename}")
+      DataTaster.logger.info("Writing SQL file to #{DataTaster.config.filename}")
       File.open(DataTaster.config.filename, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -10,6 +10,7 @@ module DataTaster
     end
 
     def serve!
+      Rails.logger.info("Writing SQL file to #{DataTaster.config.filename}")
       File.open(DataTaster.config.filename, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
@@ -32,8 +33,6 @@ module DataTaster
       collection = DataTaster::Collection.new(table_name)
       payload = collection.assemble
 
-      # Deprecated tables (skip in YAML): emit DROP for the restore target only — never execute
-      # DDL against the source. Live sampling uses +working_client+ via +safe_execute+.
       if payload.empty? && DataTaster.config.include_insert
         io.puts "DROP TABLE IF EXISTS #{safe_db_name}.#{safe_table_name};"
         return

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module DataTaster
+  # Selects and sanitizes tables from the source_db to write to a SQL file on disk.
+  class SampleToSql
+    BATCH_SIZE = 100
+
+    def initialize
+      @source_client = DataTaster.config.source_client
+    end
+
+    def serve!
+      File.open(temp_file_path, "w") do |io|
+        io.puts "SET FOREIGN_KEY_CHECKS=0;"
+        DataTaster
+          .confection
+          .keys
+          .each do |table_name|
+            write_to_sql_file(io, table_name)
+          end
+        io.puts "SET FOREIGN_KEY_CHECKS=1;"
+      end
+      temp_file_path
+    end
+
+  private
+
+    attr_reader :source_client
+
+    def write_to_sql_file(io, table_name)
+      safe_db_name = quote_ident(source_db)
+      safe_table_name = quote_ident(table_name)
+
+      collection = DataTaster::Collection.new(table_name)
+      payload = collection.assemble
+
+      # Any table that does not return SQL is considered deprecated and we should fully skip it
+      if payload.empty? && DataTaster.config.include_insert
+        DataTaster.safe_execute("DROP TABLE IF EXISTS #{table_name}", source_client)
+      else
+        select_sql = collection.export_select_sql
+        result = source_client.query(select_sql)
+
+        columns = result.fields
+        return if columns.empty?
+
+        batch = []
+        result.each do |row|
+          batch << row
+          if batch.size >= BATCH_SIZE
+            write_insert_batch(io, columns, batch, safe_db_name, safe_table_name)
+            batch.clear
+          end
+        end
+
+        write_insert_batch(io, columns, batch, safe_db_name, safe_table_name) if batch.any?
+
+        DataTaster::Sanitizer.new(table_name, payload[:sanitize]).update_sql_statements.each do |stmt|
+          io.puts "#{stmt};"
+        end
+      end
+    end
+
+    def quote_ident(name)
+      "`#{name.to_s.gsub('`', '``')}`"
+    end
+
+    def write_insert_batch(io, columns, rows, td, tn)
+      return if rows.empty?
+
+      col_list = columns.map { |c| quote_ident(c) }.join(", ")
+      tuples = rows.map do |row|
+        "(" + columns.map { |c| DataTaster::SqlLiteral.format(source_client, row[c]) }.join(", ") + ")"
+      end
+      io.puts "INSERT INTO #{td}.#{tn} (#{col_list}) VALUES"
+      io.puts "#{tuples.join(",\n")};"
+    end
+
+    def temp_file_path
+      filename = "data_taster_#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.sql"
+      File.join(Rails.root, "tmp", filename).to_s
+    end
+
+    def source_db
+      @source_db ||= source_client.query_options[:database]
+    end
+  end
+end

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -10,8 +10,7 @@ module DataTaster
     end
 
     def serve!
-      path = temp_file_path
-      File.open(path, "w") do |io|
+      File.open(DataTaster.config.filename, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
           .confection.keys
@@ -20,7 +19,6 @@ module DataTaster
           end
         io.puts "SET FOREIGN_KEY_CHECKS=1;"
       end
-      path
     end
 
   private
@@ -86,11 +84,6 @@ module DataTaster
       end
       io.puts "INSERT INTO #{safe_db_name}.#{safe_table_name} (#{col_list}) VALUES"
       io.puts "#{tuples.join(",\n")};"
-    end
-
-    def temp_file_path
-      filename = "data_taster_#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.sql"
-      File.join(Dir.tmpdir, filename).to_s
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -13,8 +13,7 @@ module DataTaster
       File.open(temp_file_path, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
-          .confection
-          .keys
+          .confection.keys
           .each do |table_name|
             write_to_sql_file(io, table_name)
           end
@@ -37,27 +36,38 @@ module DataTaster
       # Any table that does not return SQL is considered deprecated and we should fully skip it
       if payload.empty? && DataTaster.config.include_insert
         DataTaster.safe_execute("DROP TABLE IF EXISTS #{table_name}", source_client)
-      else
-        select_sql = collection.export_select_sql
-        result = source_client.query(select_sql)
+        return
+      end
 
-        columns = result.fields
-        return if columns.empty?
+      export_data(io, collection, safe_db_name, safe_table_name)
+      sanitize_data(io, table_name, payload[:sanitize])
+    end
 
-        batch = []
-        result.each do |row|
-          batch << row
-          if batch.size >= BATCH_SIZE
-            write_insert_batch(io, columns, batch, safe_db_name, safe_table_name)
-            batch.clear
-          end
+    def export_data(io, collection, safe_db_name, safe_table_name)
+      select_sql = collection.export_select_sql
+      result = source_client.query(select_sql)
+
+      columns = result.fields
+      return if columns.empty?
+
+      process_export_in_batches(io, columns, result, safe_db_name, safe_table_name)
+      append_sanitizer_statements(io, table_name, payload[:sanitize])
+    end
+
+    def process_export_in_batches(io, columns, result, safe_db_name, safe_table_name)
+      batch = []
+      result.each do |row|
+        batch << row
+        if batch.size >= BATCH_SIZE
+          write_export_batch(io, columns, batch, safe_db_name, safe_table_name)
+          batch.clear
         end
+      end
+    end
 
-        write_insert_batch(io, columns, batch, safe_db_name, safe_table_name) if batch.any?
-
-        DataTaster::Sanitizer.new(table_name, payload[:sanitize]).update_sql_statements.each do |stmt|
-          io.puts "#{stmt};"
-        end
+    def sanitize_data(io, table_name, sanitize)
+      DataTaster::Sanitizer.new(table_name, sanitize).update_sql_statements.each do |stmt|
+        io.puts "#{stmt};"
       end
     end
 
@@ -65,14 +75,14 @@ module DataTaster
       "`#{name.to_s.gsub('`', '``')}`"
     end
 
-    def write_insert_batch(io, columns, rows, td, tn)
+    def write_export_batch(io, columns, rows, safe_db_name, safe_table_name)
       return if rows.empty?
 
       col_list = columns.map { |c| quote_ident(c) }.join(", ")
       tuples = rows.map do |row|
-        "(" + columns.map { |c| DataTaster::SqlLiteral.format(source_client, row[c]) }.join(", ") + ")"
+        "(#{columns.map { |c| DataTaster::SqlLiteral.format(source_client, row[c]) }.join(', ')})"
       end
-      io.puts "INSERT INTO #{td}.#{tn} (#{col_list}) VALUES"
+      io.puts "INSERT INTO #{safe_db_name}.#{safe_table_name} (#{col_list}) VALUES"
       io.puts "#{tuples.join(",\n")};"
     end
 

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "fileutils"
+
 module DataTaster
   # Selects and sanitizes tables from the source_db to write to a SQL file on disk.
   class SampleToSql
@@ -11,6 +13,7 @@ module DataTaster
 
     def serve!
       path = temp_file_path
+      FileUtils.mkdir_p(File.dirname(path))
       File.open(path, "w") do |io|
         io.puts "SET FOREIGN_KEY_CHECKS=0;"
         DataTaster
@@ -30,8 +33,6 @@ module DataTaster
     def write_to_sql_file(io, table_name)
       safe_db_name = quote_ident(DataTaster.target_database)
       safe_table_name = quote_ident(table_name)
-
-      binding.pry
 
       collection = DataTaster::Collection.new(table_name)
       payload = collection.assemble
@@ -91,7 +92,7 @@ module DataTaster
 
     def temp_file_path
       filename = "data_taster_#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.sql"
-      File.join(Rails.root, "tmp", filename).to_s
+      File.join(Dir.tmpdir, filename).to_s
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/sample_to_sql.rb
+++ b/packages/data_taster/lib/data_taster/sample_to_sql.rb
@@ -28,8 +28,10 @@ module DataTaster
     attr_reader :source_client
 
     def write_to_sql_file(io, table_name)
-      safe_db_name = quote_ident(source_db)
+      safe_db_name = quote_ident(DataTaster.target_database)
       safe_table_name = quote_ident(table_name)
+
+      binding.pry
 
       collection = DataTaster::Collection.new(table_name)
       payload = collection.assemble
@@ -90,10 +92,6 @@ module DataTaster
     def temp_file_path
       filename = "data_taster_#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.sql"
       File.join(Rails.root, "tmp", filename).to_s
-    end
-
-    def source_db
-      @source_db ||= source_client.query_options[:database]
     end
   end
 end

--- a/packages/data_taster/lib/data_taster/sanitizer.rb
+++ b/packages/data_taster/lib/data_taster/sanitizer.rb
@@ -23,7 +23,6 @@ module DataTaster
       end
     end
 
-    # UPDATE statements that mirror +clean!+ without executing SQL (for SQL file export).
     def update_sql_statements
       return [] if skippable_table?
 

--- a/packages/data_taster/lib/data_taster/sanitizer.rb
+++ b/packages/data_taster/lib/data_taster/sanitizer.rb
@@ -23,6 +23,20 @@ module DataTaster
       end
     end
 
+    # UPDATE statements that mirror +clean!+ without executing SQL (for SQL file export).
+    def update_sql_statements
+      return [] if skippable_table?
+
+      default_selections.merge(custom_selections).filter_map do |column_name, sanitized_value|
+        sql = DataTaster::Detergent.new(
+          table_name, column_name, sanitized_value
+        ).deliver
+        next if sql == DataTaster::SKIP_CODE
+
+        sql
+      end
+    end
+
   private
 
     attr_reader :table_name, :custom_selections, :include_insert

--- a/packages/data_taster/lib/data_taster/sql_literal.rb
+++ b/packages/data_taster/lib/data_taster/sql_literal.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+require "date"
+
+module DataTaster
+  # Necessary to format Ruby values for use as MySQL INSERT literal fragments
+  module SqlLiteral
+    module_function
+
+    def format(client, value)
+      case value
+      when nil
+        "NULL"
+      when true
+        "TRUE"
+      when false
+        "FALSE"
+      when Integer
+        value.to_s
+      when Float
+        value.finite? ? value.to_s : "NULL"
+      when BigDecimal
+        value.to_s("F")
+      when Time
+        "'#{client.escape(value.strftime('%Y-%m-%d %H:%M:%S'))}'"
+      when DateTime
+        "'#{client.escape(value.to_time.strftime('%Y-%m-%d %H:%M:%S'))}'"
+      when Date
+        "'#{client.escape(value.strftime('%Y-%m-%d'))}'"
+      when Symbol
+        "'#{client.escape(value.to_s)}'"
+      when String
+        if value.encoding == Encoding::ASCII_8BIT
+          "X'#{value.unpack1('H*')}'"
+        else
+          "'#{client.escape(value)}'"
+        end
+      else
+        "'#{client.escape(value.to_s)}'"
+      end
+    end
+  end
+end

--- a/packages/data_taster/lib/data_taster/sql_literal.rb
+++ b/packages/data_taster/lib/data_taster/sql_literal.rb
@@ -6,39 +6,59 @@ require "date"
 module DataTaster
   # Necessary to format Ruby values for use as MySQL INSERT literal fragments
   module SqlLiteral
-    module_function
-
-    def format(client, value)
+    def self.format(client, value)
       case value
-      when nil
-        "NULL"
-      when true
-        "TRUE"
-      when false
-        "FALSE"
-      when Integer
-        value.to_s
-      when Float
-        value.finite? ? value.to_s : "NULL"
-      when BigDecimal
-        value.to_s("F")
-      when Time
-        "'#{client.escape(value.strftime('%Y-%m-%d %H:%M:%S'))}'"
-      when DateTime
-        "'#{client.escape(value.to_time.strftime('%Y-%m-%d %H:%M:%S'))}'"
-      when Date
-        "'#{client.escape(value.strftime('%Y-%m-%d'))}'"
-      when Symbol
-        "'#{client.escape(value.to_s)}'"
       when String
-        if value.encoding == Encoding::ASCII_8BIT
-          "X'#{value.unpack1('H*')}'"
-        else
-          "'#{client.escape(value)}'"
-        end
+        format_string_value(client, value)
+      when nil, true, false, Integer, Float, BigDecimal
+        format_scalar(value)
+      when Time, DateTime, Date
+        format_temporal(client, value)
       else
         "'#{client.escape(value.to_s)}'"
       end
     end
+
+    def self.format_temporal(client, value)
+      case value
+      when Time
+        format_escaped_time(client, value, "%Y-%m-%d %H:%M:%S")
+      when DateTime
+        format_escaped_time(client, value.to_time, "%Y-%m-%d %H:%M:%S")
+      when Date
+        format_escaped_date(client, value)
+      end
+    end
+    private_class_method :format_temporal
+
+    def self.format_scalar(value)
+      return "NULL" if value.nil?
+      return "TRUE" if value == true
+      return "FALSE" if value == false
+      return value.to_s if value.is_a?(Integer)
+      return value.finite? ? value.to_s : "NULL" if value.is_a?(Float)
+
+      value.to_s("F")
+    end
+    private_class_method :format_scalar
+
+    def self.format_escaped_time(client, time, strftime_format)
+      "'#{client.escape(time.strftime(strftime_format))}'"
+    end
+    private_class_method :format_escaped_time
+
+    def self.format_escaped_date(client, value)
+      "'#{client.escape(value.strftime('%Y-%m-%d'))}'"
+    end
+    private_class_method :format_escaped_date
+
+    def self.format_string_value(client, value)
+      if value.encoding == Encoding::ASCII_8BIT
+        "X'#{value.unpack1('H*')}'"
+      else
+        "'#{client.escape(value)}'"
+      end
+    end
+    private_class_method :format_string_value
   end
 end

--- a/packages/data_taster/spec/data_taster/collection_spec.rb
+++ b/packages/data_taster/spec/data_taster/collection_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe DataTaster::Collection do
 
     expect(result[:select]).to eq("SELECT * FROM #{source_db_name}.projects WHERE 1 = 1")
   end
+
+  describe "#export_select_sql" do
+    it "returns a plain SELECT from source_db with the confection WHERE clause" do
+      stub_config
+
+      sql = DataTaster::Collection.new("projects").export_select_sql
+
+      expect(sql).to eq("SELECT * FROM #{source_db_name}.projects WHERE 1 = 1")
+    end
+  end
 end

--- a/packages/data_taster/spec/data_taster/export_graph_compiler_spec.rb
+++ b/packages/data_taster/spec/data_taster/export_graph_compiler_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Lightweight ActiveRecord graph — no DB connection (explicit primary keys).
+module ExportGraphCompilerSpec
+  module Dealer
+    class Dealer < ActiveRecord::Base
+      self.table_name = "dealer_dealers"
+      self.primary_key = "id"
+    end
+  end
+
+  module CreditApplication
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+    end
+
+    class LoanApplicationStatus < ApplicationRecord
+      self.table_name = "credit_application_loan_application_statuses"
+      self.primary_key = "id"
+    end
+
+    class LoanApplicationApplicant < ApplicationRecord
+      self.table_name = "credit_application_loan_application_applicants"
+      self.primary_key = "id"
+      belongs_to :loan_application, class_name: "ExportGraphCompilerSpec::CreditApplication::LoanApplication"
+      belongs_to :applicant, class_name: "ExportGraphCompilerSpec::CreditApplication::Applicant"
+    end
+
+    class Applicant < ApplicationRecord
+      self.table_name = "credit_application_applicants"
+      self.primary_key = "id"
+    end
+
+    class LoanApplicationOffer < ApplicationRecord
+      self.table_name = "credit_application_loan_application_offers"
+      self.primary_key = "id"
+    end
+
+    class ActivityFeedItem < ApplicationRecord
+      self.table_name = "credit_application_activity_feed_items"
+      self.primary_key = "id"
+    end
+
+    class LoanApplication < ApplicationRecord
+      self.table_name = "credit_application_loan_applications"
+      self.primary_key = "id"
+      belongs_to :dealer, class_name: "ExportGraphCompilerSpec::Dealer::Dealer"
+      has_one :status, class_name: "ExportGraphCompilerSpec::CreditApplication::LoanApplicationStatus"
+      has_many :loan_application_applicants, class_name: "ExportGraphCompilerSpec::CreditApplication::LoanApplicationApplicant"
+      has_many :applicants, through: :loan_application_applicants
+      has_many :offers, class_name: "ExportGraphCompilerSpec::CreditApplication::LoanApplicationOffer"
+      has_many :activity_feed_items, class_name: "ExportGraphCompilerSpec::CreditApplication::ActivityFeedItem",
+                                     as: :context
+    end
+  end
+end
+
+RSpec.describe DataTaster::ExportGraphCompiler do
+  let(:graph_anchor_allowlist) { nil }
+  let(:source_client) { instance_double(Mysql2::Client, query_options: { database: "spec_source_db" }) }
+  let(:stub_config) do
+    DataTaster::Config.new(
+      months: nil,
+      list: [],
+      source_client: source_client,
+      working_client: nil,
+      include_insert: false,
+      filename: nil,
+      graph_anchor_allowlist: graph_anchor_allowlist
+    )
+  end
+
+  before { allow(DataTaster).to receive(:config).and_return(stub_config) }
+
+  describe ".merge_into!" do
+    let(:graph) do
+      {
+        "anchor" => {
+          "model" => "ExportGraphCompilerSpec::CreditApplication::LoanApplication",
+          "where_sql" => "created_at >= '2000-01-01'",
+          "order" => "id DESC",
+          "limit" => 10,
+        },
+        "includes" => %w[status loan_application_applicants applicants offers],
+      }
+    end
+
+    it "expands graphs into table clauses, including the anchor table, and drops the reserved key" do
+      hash = {
+        "data_taster_export_graphs" => { "g" => graph },
+        "other_table" => "1 = 1",
+      }
+      described_class.merge_into!(hash)
+
+      expect(hash).not_to have_key("data_taster_export_graphs")
+      expect(hash["credit_application_loan_applications"])
+        .to include("`id` IN (", "LIMIT 10", "spec_source_db")
+      expect(hash["credit_application_loan_application_statuses"]).to include("loan_application_id")
+      expect(hash["credit_application_loan_application_applicants"]).to include("loan_application_id")
+      expect(hash["credit_application_applicants"]).to include("credit_application_loan_application_applicants")
+      expect(hash["credit_application_loan_application_offers"]).to include("loan_application_id")
+      expect(hash["other_table"]).to eq("1 = 1")
+    end
+
+    it "lets explicit table keys override compiled fragments" do
+      hash = {
+        "data_taster_export_graphs" => { "g" => graph },
+        "credit_application_loan_application_statuses" => "1 = 0",
+      }
+      described_class.merge_into!(hash)
+
+      expect(hash["credit_application_loan_application_statuses"]).to eq("1 = 0")
+    end
+
+    it "raises on unknown associations" do
+      bad = graph.merge("includes" => %w[not_a_real_assoc])
+      hash = { "data_taster_export_graphs" => { "g" => bad } }
+      expect { described_class.merge_into!(hash) }.to raise_error(
+        DataTaster::ExportGraphCompiler::Error,
+        /Unknown association/
+      )
+    end
+
+    context "with graph_anchor_allowlist" do
+      let(:graph_anchor_allowlist) { ["ExportGraphCompilerSpec::"] }
+
+      it "raises when the anchor model is outside the allowlist" do
+        bad_anchor = graph.merge(
+          "anchor" => graph["anchor"].merge("model" => "Array")
+        )
+        hash = { "data_taster_export_graphs" => { "g" => bad_anchor } }
+        expect { described_class.merge_into!(hash) }.to raise_error(
+          DataTaster::ExportGraphCompiler::Error,
+          /not allowed/
+        )
+      end
+    end
+
+    it "skips polymorphic-inverse includes without failing" do
+      poly_graph = graph.merge("includes" => %w[activity_feed_items])
+      hash = { "data_taster_export_graphs" => { "g" => poly_graph } }
+      allow(DataTaster.logger).to receive(:info)
+      described_class.merge_into!(hash)
+
+      expect(hash).not_to have_key("credit_application_activity_feed_items")
+    end
+
+    it "emits belongs_to parent constraints" do
+      dealer_graph = graph.merge("includes" => %w[dealer])
+      hash = { "data_taster_export_graphs" => { "g" => dealer_graph } }
+      described_class.merge_into!(hash)
+
+      expect(hash["dealer_dealers"]).to include("dealer_id").and include("credit_application_loan_applications")
+    end
+  end
+end

--- a/packages/data_taster/spec/data_taster/integration/default_sanitization_dump_spec.rb
+++ b/packages/data_taster/spec/data_taster/integration/default_sanitization_dump_spec.rb
@@ -43,18 +43,4 @@ RSpec.describe "DataTaster Default Sanitization Dump Integration", type: :integr
       expect(result["dob"]).to eq(expected_date)
     end
   end
-
-private
-
-  def setup_source_data
-    now = Time.current.strftime("%Y-%m-%d %H:%M:%S")
-    insert_user_sql = <<-SQL.squish
-      INSERT INTO users (id, encrypted_password, ssn, passport_number, license_number, date_of_birth, dob, notes, body,
-       compensation, income, email, email2, address, address2, created_at, updated_at)
-      VALUES (1, 'encrypted123', '123-45-6789', 'P123456789', 'L123456789', '1990-01-01', '1990-01-01',
-        'Private notes', 'Body text', 50000.00, 60000.00, 'test@example.com', 'test2@example.com', '123 Main St',
-        'Apt 1', '#{now}', '#{now}')
-    SQL
-    source_db_client.query(insert_user_sql)
-  end
 end

--- a/packages/data_taster/spec/data_taster/integration/sql_file_export_spec.rb
+++ b/packages/data_taster/spec/data_taster/integration/sql_file_export_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "DataTaster SQL file export", type: :integration do
+  include DatabaseHelper
+
+  let(:yaml_path) { File.join(__dir__, "..", "..", "fixtures", "full_users_dump_tables.yml") }
+  let(:export_path) { File.join(Dir.tmpdir, "data_taster_sql_export_#{Process.pid}.sql") }
+
+  before do
+    DataTaster.config(
+      source_client: source_db_client,
+      working_client: dump_db_client,
+      list: [yaml_path],
+      include_insert: true,
+      filename: export_path
+    )
+    setup_source_data
+  end
+
+  after do
+    FileUtils.rm_f(export_path)
+    DataTaster.reset!
+  end
+
+  describe "dump file content" do
+    it "qualifies INSERTs and sanitizer UPDATEs with the working (restore target) DB, and does not mutate the source" do
+      count_before = source_db_client.query("SELECT COUNT(*) AS cnt FROM users").first["cnt"]
+
+      path = DataTaster.sample_to_sql_file!
+
+      expect(path).to eq(File.expand_path(export_path))
+      expect(File).to exist(path)
+
+      count_after = source_db_client.query("SELECT COUNT(*) AS cnt FROM users").first["cnt"]
+      expect(count_after).to eq(count_before)
+
+      sql = File.read(path)
+      expect(sql).to start_with("SET FOREIGN_KEY_CHECKS=0;\n")
+      expect(sql).to include("SET FOREIGN_KEY_CHECKS=1;")
+
+      quoted_dump_db = "`#{dump_db_name.gsub('`', '``')}`"
+      expect(sql).to include("INSERT INTO #{quoted_dump_db}.`users`")
+
+      expect(sql).to include("UPDATE #{dump_db_name}.users")
+
+      expect(sql).to include("CONCAT('users_', id, '@nitrophrg.com')")
+      expect(sql).to include("test@example.com")
+    end
+  end
+end

--- a/packages/data_taster/spec/data_taster/integration/sql_file_export_spec.rb
+++ b/packages/data_taster/spec/data_taster/integration/sql_file_export_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "DataTaster SQL file export", type: :integration do
       working_client: dump_db_client,
       list: [yaml_path],
       include_insert: true,
-      filename: export_path
+      filename: File.expand_path(export_path)
     )
     setup_source_data
   end
@@ -28,8 +28,9 @@ RSpec.describe "DataTaster SQL file export", type: :integration do
     it "qualifies INSERTs and sanitizer UPDATEs with the working (restore target) DB, and does not mutate the source" do
       count_before = source_db_client.query("SELECT COUNT(*) AS cnt FROM users").first["cnt"]
 
-      path = DataTaster.sample_to_sql_file!
+      DataTaster.sample_to_sql_file!
 
+      path = File.expand_path(DataTaster.config.filename)
       expect(path).to eq(File.expand_path(export_path))
       expect(File).to exist(path)
 

--- a/packages/data_taster/spec/data_taster/sanitizer_spec.rb
+++ b/packages/data_taster/spec/data_taster/sanitizer_spec.rb
@@ -20,6 +20,43 @@ RSpec.describe DataTaster::Sanitizer do
     allow(DataTaster).to receive(:confection).and_return(confection_stub)
   end
 
+  describe "#update_sql_statements" do
+    context "when table is skippable" do
+      it "returns an empty array when confection is blank" do
+        stub_config
+        allow(confection_stub).to receive(:[]).with("users").and_return(nil)
+
+        expect(described_class.new("users", {}).update_sql_statements).to eq([])
+      end
+    end
+
+    context "when table is not skippable" do
+      before do
+        allow(confection_stub).to receive(:[]).with("users").and_return("some_config")
+      end
+
+      it "returns UPDATE strings and does not call safe_execute" do
+        stub_config
+        allow(DataTaster).to receive(:safe_execute)
+
+        stmts = described_class.new("users", {}).update_sql_statements
+
+        expect(stmts).to all(be_a(String))
+        expect(stmts.join(" ")).to include("UPDATE test_dump.users")
+        expect(DataTaster).not_to have_received(:safe_execute)
+      end
+
+      it "omits columns whose value is skip code" do
+        stub_config
+        sanitizer = described_class.new("users", { "ssn" => DataTaster::SKIP_CODE })
+
+        joined = sanitizer.update_sql_statements.join(" ")
+        expect(joined).not_to include("SET ssn =")
+        expect(joined).to include("SET encrypted_password = NULL")
+      end
+    end
+  end
+
   describe "#clean!" do
     context "when table is skippable" do
       before do

--- a/packages/data_taster/spec/support/database_helper.rb
+++ b/packages/data_taster/spec/support/database_helper.rb
@@ -47,6 +47,18 @@ module DatabaseHelper
   # Methods available for use during specs
   delegate :dump_db_name, :dump_db_client, :source_db_name, :source_db_client, to: :db_config
 
+  def setup_source_data
+    now = Time.current.strftime("%Y-%m-%d %H:%M:%S")
+    insert_user_sql = <<-SQL.squish
+      INSERT INTO users (id, encrypted_password, ssn, passport_number, license_number, date_of_birth, dob, notes, body,
+       compensation, income, email, email2, address, address2, created_at, updated_at)
+      VALUES (1, 'encrypted123', '123-45-6789', 'P123456789', 'L123456789', '1990-01-01', '1990-01-01',
+        'Private notes', 'Body text', 50000.00, 60000.00, 'test@example.com', 'test2@example.com', '123 Main St',
+        'Apt 1', '#{now}', '#{now}')
+    SQL
+    source_db_client.query(insert_user_sql)
+  end
+
 private
 
   def db_config


### PR DESCRIPTION
#### Description

This PR introduces a graph-based export path for Data Taster: 
- YAML can declare data_taster_export_graphs with an anchor model (where_sql, order, limit) and includes that mirror ActiveRecord associations. 
- Those graphs are compiled into per-table WHERE fragments so a single sample stays consistent across related rows.

It adds ExportGraphCompiler (including graph_anchor_allowlist and resolving the source DB from the MySQL client), safer YAML loading for these configs, and MySQL-safe SQL for limited anchor subqueries (derived-table wrapper instead of IN (SELECT … ORDER BY … LIMIT …)). Specs can skip the dummy-app DB with DATA_TASTER_SKIP_DB_SETUP=1.

- Consuming apps (like Tempo) can pair this with component data_taster_export_tables.yml files that mix ordinary table clauses with graphs, so dumps follow a graph export model instead of maintaining large, hand-written join logic in flat YAML alone.
