### PR TITLE
[SHD-1901] Add SCIM get endpoint

### DIFF
--- a/packages/two_percent/Gemfile.lock
+++ b/packages/two_percent/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    two_percent (1.0.0)
+    two_percent (1.1.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -3,18 +3,18 @@
 module TwoPercent
   class ScimController < ApplicationController
     def create
-      log_scim_operation("create", "start")
+      record = with_scim_logging("create") do
+        # Persist to two_percent tables first (validates SCIM schema)
+        record = persist_scim_record(scim_params)
 
-      # Persist to two_percent tables first (validates SCIM schema)
-      record = persist_scim_record(scim_params)
+        # Reload with associations for domain event and response
+        record = reload_with_members(record)
 
-      # Reload with associations for domain event and response
-      record = reload_with_members(record)
+        # Publish domain event (not SCIM-specific)
+        publish_created_event(record)
 
-      # Publish domain event (not SCIM-specific)
-      publish_created_event(record)
-
-      log_scim_operation("create", "complete", record.scim_id)
+        record
+      end
 
       # RFC 7644: 201 Created with Location header and resource body
       response.headers["Location"] = scim_resource_url(record)
@@ -22,51 +22,51 @@ module TwoPercent
     end
 
     def update
-      log_scim_operation("update", "start")
+      record = with_scim_logging("update") do
+        # Find existing record
+        record = find_scim_record(params[:id])
 
-      # Find existing record
-      record = find_scim_record(params[:id])
+        # Apply SCIM PATCH operations (RFC 7644 compliance)
+        processor = TwoPercent::Scim::PatchProcessor.new(scim_params)
+        current_scim_data = record.scim_data || {}
+        patched_data = processor.apply_to_hash(current_scim_data)
 
-      # Apply SCIM PATCH operations (RFC 7644 compliance)
-      processor = TwoPercent::Scim::PatchProcessor.new(scim_params)
-      current_scim_data = record.scim_data || {}
-      patched_data = processor.apply_to_hash(current_scim_data)
+        # Persist patched data
+        patched_data["id"] = params[:id] # Ensure ID is present
+        updated_record = persist_scim_record(patched_data)
 
-      # Persist patched data
-      patched_data["id"] = params[:id] # Ensure ID is present
-      updated_record = persist_scim_record(patched_data)
+        # Reload with associations for domain event and response
+        updated_record = reload_with_members(updated_record)
 
-      # Reload with associations for domain event and response
-      updated_record = reload_with_members(updated_record)
+        # Publish domain event with final state
+        publish_updated_event(updated_record)
 
-      # Publish domain event with final state
-      publish_updated_event(updated_record)
-
-      log_scim_operation("update", "complete", record.scim_id)
+        updated_record
+      end
 
       # RFC 7644: 200 OK with updated resource body
-      render json: updated_record.to_scim_representation, status: :ok
+      render json: record.to_scim_representation, status: :ok
     end
 
     def replace
-      log_scim_operation("replace", "start")
-
       # Upsert record (create or replace)
       was_new = !model_class.exists_by_scim_id?(params[:id])
 
-      record = upsert_scim_record(params[:id], scim_params)
+      record = with_scim_logging("replace") do
+        record = upsert_scim_record(params[:id], scim_params)
 
-      # Reload with associations for domain event and response
-      record = reload_with_members(record)
+        # Reload with associations for domain event and response
+        record = reload_with_members(record)
 
-      # Publish appropriate domain event
-      if was_new
-        publish_created_event(record)
-      else
-        publish_updated_event(record)
+        # Publish appropriate domain event
+        if was_new
+          publish_created_event(record)
+        else
+          publish_updated_event(record)
+        end
+
+        record
       end
-
-      log_scim_operation("replace", "complete", record.scim_id)
 
       # RFC 7644: 201 Created (if new) or 200 OK (if replaced)
       if was_new
@@ -78,34 +78,32 @@ module TwoPercent
     end
 
     def destroy
-      log_scim_operation("delete", "start")
+      scim_id = with_scim_logging("delete") do
+        # Find and destroy record
+        record = find_scim_record(params[:id])
+        scim_id = record.scim_id
 
-      # Find and destroy record
-      record = find_scim_record(params[:id])
-      scim_id = record.scim_id
+        # Destroy record
+        model_class.destroy_by_scim_id(scim_id)
 
-      # Destroy record
-      model_class.destroy_by_scim_id(scim_id)
+        # Publish domain delete event
+        publish_deleted_event(scim_id)
 
-      # Publish domain delete event
-      publish_deleted_event(scim_id)
-
-      log_scim_operation("delete", "complete", scim_id)
+        scim_id
+      end
 
       # RFC 7644: 204 No Content
       head :no_content
     end
 
     def show
-      log_scim_operation("get", "start", params[:id])
+      record = with_scim_logging("get") do
+        # Find record (raises RecordNotFound if not exists)
+        record = find_scim_record(params[:id])
 
-      # Find record (raises RecordNotFound if not exists)
-      record = find_scim_record(params[:id])
-
-      # Reload with associations for complete SCIM representation
-      record = reload_with_members(record)
-
-      log_scim_operation("get", "complete", record.scim_id)
+        # Reload with associations for complete SCIM representation
+        reload_with_members(record)
+      end
 
       # RFC 7644: 200 OK with resource body (no domain events for read operations)
       render json: record.to_scim_representation, status: :ok
@@ -170,6 +168,14 @@ module TwoPercent
       # Ensure scim_id is in the hash
       scim_hash_with_id = scim_hash.merge("id" => scim_id)
       persist_scim_record(scim_hash_with_id)
+    end
+
+    def with_scim_logging(operation)
+      log_scim_operation(operation, "start", params[:id])
+      record = yield
+      scim_id = record.respond_to?(:scim_id) ? record.scim_id : record
+      log_scim_operation(operation, "complete", scim_id || params[:id])
+      record
     end
 
     def log_scim_operation(operation, stage, scim_id = nil)
@@ -241,8 +247,6 @@ module TwoPercent
     def reload_with_members(record)
       model_class.includes(association_name).find(record.id)
     end
-
-    # Index action helpers
 
     # Build base query scope with optional filtering
     def build_query_scope

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -259,11 +259,18 @@ module TwoPercent
     def build_query_scope
       base_scope = user_resource? ? model_class.all : model_class.where(resource_type: params[:resource_type])
 
-      return base_scope unless params[:query].present?
+      # Apply query filtering if present
+      scope = if params[:query].present?
+                # Sanitize LIKE wildcards (%, _, \) before interpolating into pattern
+                sanitized_query = ActiveRecord::Base.sanitize_sql_like(params[:query])
+                base_scope.where("LOWER(display_name) LIKE LOWER(?) ESCAPE '\\'", "%#{sanitized_query}%")
+              else
+                base_scope
+              end
 
-      # Sanitize LIKE wildcards (%, _, \) before interpolating into pattern
-      sanitized_query = ActiveRecord::Base.sanitize_sql_like(params[:query])
-      base_scope.where("LOWER(display_name) LIKE LOWER(?) ESCAPE '\\'", "%#{sanitized_query}%")
+      # Order by id for deterministic pagination results
+      # Without ORDER BY, paginated results are non-deterministic and can return duplicates/skip records
+      scope.order(:id)
     end
 
     # Apply SCIM pagination (RFC 7644 uses 1-based indexing)

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -105,6 +105,45 @@ module TwoPercent
       head :no_content
     end
 
+    def show
+      log_scim_operation("get", "start", params[:id])
+
+      # Find record (raises RecordNotFound if not exists)
+      record = find_scim_record(params[:id])
+
+      # Reload with associations for complete SCIM representation
+      record = reload_with_members(record)
+
+      log_scim_operation("get", "complete", record.scim_id)
+
+      # RFC 7644: 200 OK with resource body (no domain events for read operations)
+      render json: record.to_scim_representation, status: :ok
+    end
+
+    def index
+      log_scim_operation("list", "start")
+
+      # Build base query scope
+      scope = build_query_scope
+
+      # Get total count before pagination
+      total_count = scope.count
+
+      # Apply pagination
+      paginated_scope = apply_pagination(scope)
+
+      # Load records with associations
+      records = load_records_with_associations(paginated_scope)
+
+      # Build RFC 7644 ListResponse
+      list_response = build_list_response(records, total_count)
+
+      log_scim_operation("list", "complete")
+
+      # RFC 7644: 200 OK with ListResponse (no domain events for read operations)
+      render json: list_response, status: :ok
+    end
+
   private
 
     def scim_params
@@ -222,6 +261,54 @@ module TwoPercent
       else
         TwoPercent::ScimGroup.includes(:scim_users).find(record.id)
       end
+    end
+
+    # Index action helpers
+
+    # Build base query scope with optional filtering
+    def build_query_scope
+      base_scope = user_resource? ? TwoPercent::ScimUser.all : TwoPercent::ScimGroup.where(resource_type: params[:resource_type])
+
+      return base_scope unless params[:query].present?
+
+      # Apply query filter (display_name substring match, case-insensitive)
+      base_scope.where("LOWER(display_name) LIKE LOWER(?)", "%#{params[:query]}%")
+    end
+
+    # Apply SCIM pagination (RFC 7644 uses 1-based indexing)
+    def apply_pagination(scope)
+      start_index = (params[:startIndex] || 1).to_i
+      count = (params[:count] || 100).to_i
+
+      # Enforce maximum count limit
+      count = [count, 1000].min
+
+      # Convert SCIM 1-based startIndex to 0-based offset
+      offset = [start_index - 1, 0].max
+
+      scope.offset(offset).limit(count)
+    end
+
+    # Load records with associations
+    def load_records_with_associations(scope)
+      if user_resource?
+        scope.includes(:scim_groups).to_a
+      else
+        scope.includes(:scim_users).to_a
+      end
+    end
+
+    # Build RFC 7644 ListResponse format
+    def build_list_response(records, total_count)
+      start_index = (params[:startIndex] || 1).to_i
+
+      {
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+        totalResults: total_count,
+        startIndex: start_index,
+        itemsPerPage: records.size,
+        Resources: records.map(&:to_scim_representation),
+      }
     end
   end
 end

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -52,12 +52,7 @@ module TwoPercent
       log_scim_operation("replace", "start")
 
       # Upsert record (create or replace)
-      was_new =
-        if user_resource?
-          !TwoPercent::ScimUser.exists_by_scim_id?(params[:id])
-        else
-          !TwoPercent::ScimGroup.exists_by_scim_id?(params[:id])
-        end
+      was_new = !model_class.exists_by_scim_id?(params[:id])
 
       record = upsert_scim_record(params[:id], scim_params)
 
@@ -90,11 +85,7 @@ module TwoPercent
       scim_id = record.scim_id
 
       # Destroy record
-      if user_resource?
-        TwoPercent::ScimUser.destroy_by_scim_id(scim_id)
-      else
-        TwoPercent::ScimGroup.destroy_by_scim_id(scim_id)
-      end
+      model_class.destroy_by_scim_id(scim_id)
 
       # Publish domain delete event
       publish_deleted_event(scim_id)
@@ -169,17 +160,8 @@ module TwoPercent
     end
 
     def find_scim_record(scim_id)
-      record =
-        if user_resource?
-          TwoPercent::ScimUser.find_by_scim_id(scim_id)
-        elsif group_resource?
-          TwoPercent::ScimGroup.find_by_scim_id(scim_id)
-        else
-          raise ArgumentError, "Unknown resource type: #{params[:resource_type]}"
-        end
-
+      record = model_class.find_by_scim_id(scim_id)
       raise ActiveRecord::RecordNotFound, "Resource \"#{scim_id}\" not found" unless record
-
       record
     end
 
@@ -256,18 +238,14 @@ module TwoPercent
 
     # Reload record with associations (users load groups, groups load members)
     def reload_with_members(record)
-      if user_resource?
-        TwoPercent::ScimUser.includes(:scim_groups).find(record.id)
-      else
-        TwoPercent::ScimGroup.includes(:scim_users).find(record.id)
-      end
+      model_class.includes(association_name).find(record.id)
     end
 
     # Index action helpers
 
     # Build base query scope with optional filtering
     def build_query_scope
-      base_scope = user_resource? ? TwoPercent::ScimUser.all : TwoPercent::ScimGroup.where(resource_type: params[:resource_type])
+      base_scope = user_resource? ? model_class.all : model_class.where(resource_type: params[:resource_type])
 
       return base_scope unless params[:query].present?
 
@@ -291,11 +269,7 @@ module TwoPercent
 
     # Load records with associations
     def load_records_with_associations(scope)
-      if user_resource?
-        scope.includes(:scim_groups).to_a
-      else
-        scope.includes(:scim_users).to_a
-      end
+      scope.includes(association_name).to_a
     end
 
     # Build RFC 7644 ListResponse format
@@ -309,6 +283,16 @@ module TwoPercent
         itemsPerPage: records.size,
         Resources: records.map(&:to_scim_representation),
       }
+    end
+
+    # Dynamic dispatch helpers
+
+    def model_class
+      user_resource? ? TwoPercent::ScimUser : TwoPercent::ScimGroup
+    end
+
+    def association_name
+      user_resource? ? :scim_groups : :scim_users
     end
   end
 end

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -254,8 +254,9 @@ module TwoPercent
 
       return base_scope unless params[:query].present?
 
-      # Apply query filter (display_name substring match, case-insensitive)
-      base_scope.where("LOWER(display_name) LIKE LOWER(?)", "%#{params[:query]}%")
+      # Sanitize LIKE wildcards (%, _, \) before interpolating into pattern
+      sanitized_query = ActiveRecord::Base.sanitize_sql_like(params[:query])
+      base_scope.where("LOWER(display_name) LIKE LOWER(?) ESCAPE '\\'", "%#{sanitized_query}%")
     end
 
     # Apply SCIM pagination (RFC 7644 uses 1-based indexing)

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -97,6 +97,8 @@ module TwoPercent
     end
 
     def show
+      validate_resource_type!
+
       record = with_scim_logging("get") do
         # Find record (raises RecordNotFound if not exists)
         record = find_scim_record(params[:id])
@@ -110,6 +112,7 @@ module TwoPercent
     end
 
     def index
+      validate_resource_type!
       log_scim_operation("list", "start")
 
       # Build base query scope
@@ -145,6 +148,12 @@ module TwoPercent
 
     def group_resource?
       TwoPercent.config.group_resource_types.include?(params[:resource_type])
+    end
+
+    def validate_resource_type!
+      return if user_resource? || group_resource?
+
+      raise ArgumentError, "Unknown resource type: #{params[:resource_type]}"
     end
 
     def persist_scim_record(scim_hash)

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -17,8 +17,7 @@ module TwoPercent
       end
 
       # RFC 7644: 201 Created with Location header and resource body
-      response.headers["Location"] = scim_resource_url(record)
-      render json: record.to_scim_representation, status: :created
+      render json: record.to_scim_representation, status: :created, location: scim_resource_url(record)
     end
 
     def update
@@ -70,8 +69,7 @@ module TwoPercent
 
       # RFC 7644: 201 Created (if new) or 200 OK (if replaced)
       if was_new
-        response.headers["Location"] = scim_resource_url(record)
-        render json: record.to_scim_representation, status: :created
+        render json: record.to_scim_representation, status: :created, location: scim_resource_url(record)
       else
         render json: record.to_scim_representation, status: :ok
       end

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -285,8 +285,6 @@ module TwoPercent
       }
     end
 
-    # Dynamic dispatch helpers
-
     def model_class
       user_resource? ? TwoPercent::ScimUser : TwoPercent::ScimGroup
     end

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -162,6 +162,7 @@ module TwoPercent
     def find_scim_record(scim_id)
       record = model_class.find_by_scim_id(scim_id)
       raise ActiveRecord::RecordNotFound, "Resource \"#{scim_id}\" not found" unless record
+
       record
     end
 

--- a/packages/two_percent/app/controllers/two_percent/scim_controller.rb
+++ b/packages/two_percent/app/controllers/two_percent/scim_controller.rb
@@ -144,7 +144,7 @@ module TwoPercent
     end
 
     def group_resource?
-      %w[Groups Departments Territories Roles Titles].include?(params[:resource_type])
+      TwoPercent.config.group_resource_types.include?(params[:resource_type])
     end
 
     def persist_scim_record(scim_hash)

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -30,7 +30,7 @@ module TwoPercent
     # @return [TwoPercent::ScimGroup] The persisted group record
     # @raise [TwoPercent::Scim::ValidationError] If SCIM data fails schema validation
     def self.upsert_from_scim(resource_type, scim_hash, correlation_id: nil)
-      # Generate ID if not present (for POST/create operations)
+      # Generate SCIM id (stored as scim_id) if not provided (typical for POST operations)
       scim_hash = scim_hash.dup
       scim_hash["id"] ||= SecureRandom.uuid
 

--- a/packages/two_percent/app/models/two_percent/scim_user.rb
+++ b/packages/two_percent/app/models/two_percent/scim_user.rb
@@ -26,7 +26,7 @@ module TwoPercent
     # @return [TwoPercent::ScimUser] The persisted user record
     # @raise [TwoPercent::Scim::ValidationError] If SCIM data fails schema validation
     def self.upsert_from_scim(scim_hash, correlation_id: nil)
-      # Generate ID if not present (for POST/create operations)
+      # Generate SCIM id (stored as scim_id) if not provided (typical for POST operations)
       scim_hash = scim_hash.dup
       scim_hash["id"] ||= SecureRandom.uuid
 

--- a/packages/two_percent/config/routes.rb
+++ b/packages/two_percent/config/routes.rb
@@ -2,6 +2,11 @@
 
 TwoPercent::Engine.routes.draw do
   post "/Bulk" => "bulk#_dispatch"
+  
+  # GET routes must come before POST to ensure proper precedence
+  get "/:resource_type/:id" => "scim#show"
+  get "/:resource_type" => "scim#index"
+  
   post "/:resource_type" => "scim#create"
   patch "/:resource_type/:id" => "scim#update"
   put "/:resource_type/:id" => "scim#replace"

--- a/packages/two_percent/config/routes.rb
+++ b/packages/two_percent/config/routes.rb
@@ -2,11 +2,11 @@
 
 TwoPercent::Engine.routes.draw do
   post "/Bulk" => "bulk#_dispatch"
-  
+
   # GET routes must come before POST to ensure proper precedence
   get "/:resource_type/:id" => "scim#show"
   get "/:resource_type" => "scim#index"
-  
+
   post "/:resource_type" => "scim#create"
   patch "/:resource_type/:id" => "scim#update"
   put "/:resource_type/:id" => "scim#replace"

--- a/packages/two_percent/docs/CHANGELOG.md
+++ b/packages/two_percent/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-- **GET Endpoints**: Read operations with RFC 7644 ListResponse format
+## [1.1.0] - 2026-06-05
+
+- **GET Endpoints**: Read operations with RFC 7644 ListResponse format [#436](https://github.com/powerhome/power-tools/pull/436)
   - `GET /scim/:resource_type/:id` - Single resource retrieval
   - `GET /scim/:resource_type` - List/search resources with pagination
   - RFC 7644 ListResponse format: `{schemas, totalResults, startIndex, itemsPerPage, Resources}`
@@ -10,7 +12,7 @@
   - Eager loading of associations (users → groups, groups → members)
   - No domain events published for read operations
   - Note: RFC 7644 `filter`, `sortBy`, and `attributes` parameters not yet supported
-- **Configurable Group Resource Types**: `config.group_resource_types` setting
+- **Configurable Group Resource Types**: `config.group_resource_types` setting [#436](https://github.com/powerhome/power-tools/pull/436
   - Defaults to `%w[Groups]` (SCIM standard type only)
   - Configure additional types (e.g., Departments, Territories) in initializer
 

--- a/packages/two_percent/docs/CHANGELOG.md
+++ b/packages/two_percent/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+- **GET Endpoints**: Full RFC 7644-compliant read operations
+  - `GET /scim/:resource_type/:id` - Single resource retrieval
+  - `GET /scim/:resource_type` - List/search resources with pagination
+  - RFC 7644 ListResponse format: `{schemas, totalResults, startIndex, itemsPerPage, Resources}`
+  - Query filtering: `?query=` parameter for display_name substring match (case-insensitive)
+  - SCIM pagination: `?startIndex=` (1-based) and `?count=` parameters (default: 100, max: 1000)
+  - Supports all resource types: Users, Groups, Departments, Territories, Roles, Titles
+  - Eager loading of associations (users → groups, groups → members)
+  - No domain events published for read operations
+
 ## [1.0.0] - 2026-05-20
 
 - **Domain Events System**: TwoPercent now publishes domain events when SCIM resources change [#424](https://github.com/powerhome/power-tools/pull/424)

--- a/packages/two_percent/docs/CHANGELOG.md
+++ b/packages/two_percent/docs/CHANGELOG.md
@@ -6,10 +6,13 @@
   - RFC 7644 ListResponse format: `{schemas, totalResults, startIndex, itemsPerPage, Resources}`
   - Legacy query filtering: `?query=` parameter for display_name substring match (case-insensitive)
   - SCIM pagination: `?startIndex=` (1-based) and `?count=` parameters (default: 100, max: 1000)
-  - Supports all resource types: Users, Groups, Departments, Territories, Roles, Titles
+  - Supports all configured resource types (Users + configured group types)
   - Eager loading of associations (users → groups, groups → members)
   - No domain events published for read operations
   - Note: RFC 7644 `filter`, `sortBy`, and `attributes` parameters not yet supported
+- **Configurable Group Resource Types**: `config.group_resource_types` setting
+  - Defaults to `%w[Groups]` (SCIM standard type only)
+  - Configure additional types (e.g., Departments, Territories) in initializer
 
 ## [1.0.0] - 2026-05-20
 

--- a/packages/two_percent/docs/CHANGELOG.md
+++ b/packages/two_percent/docs/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## [Unreleased]
 
-- **GET Endpoints**: Full RFC 7644-compliant read operations
+- **GET Endpoints**: Read operations with RFC 7644 ListResponse format
   - `GET /scim/:resource_type/:id` - Single resource retrieval
   - `GET /scim/:resource_type` - List/search resources with pagination
   - RFC 7644 ListResponse format: `{schemas, totalResults, startIndex, itemsPerPage, Resources}`
-  - Query filtering: `?query=` parameter for display_name substring match (case-insensitive)
+  - Legacy query filtering: `?query=` parameter for display_name substring match (case-insensitive)
   - SCIM pagination: `?startIndex=` (1-based) and `?count=` parameters (default: 100, max: 1000)
   - Supports all resource types: Users, Groups, Departments, Territories, Roles, Titles
   - Eager loading of associations (users → groups, groups → members)
   - No domain events published for read operations
+  - Note: RFC 7644 `filter`, `sortBy`, and `attributes` parameters not yet supported
 
 ## [1.0.0] - 2026-05-20
 

--- a/packages/two_percent/docs/README.md
+++ b/packages/two_percent/docs/README.md
@@ -62,7 +62,7 @@ graph TD
 
 ## API Endpoints
 
-TwoPercent provides RFC 7644-compliant SCIM 2.0 endpoints for all standard CRUD operations.
+TwoPercent provides SCIM 2.0 endpoints for all standard CRUD operations with RFC 7644 ListResponse format for collection endpoints.
 
 ### Authentication
 
@@ -140,7 +140,7 @@ Authorization: Bearer <token>
 
 ### GET - List/Search Resources
 
-Retrieve multiple resources with optional filtering and pagination. Returns RFC 7644-compliant ListResponse format.
+Retrieve multiple resources with optional filtering and pagination. Returns RFC 7644 ListResponse format with legacy query filtering.
 
 **Request:**
 ```http

--- a/packages/two_percent/docs/README.md
+++ b/packages/two_percent/docs/README.md
@@ -68,6 +68,10 @@ TwoPercent provides RFC 7644-compliant SCIM 2.0 endpoints for all standard CRUD 
 
 All endpoints require authentication via the configured `authenticate` block (see Configuration section). Typically uses HTTP Bearer token authentication.
 
+### Content Types
+
+Per RFC 7644, requests should use `Content-Type: application/scim+json`. For backward compatibility, `application/json` is also accepted.
+
 ### Resource Types
 
 **Users:**
@@ -212,7 +216,7 @@ Create a new SCIM resource. Publishes domain events.
 ```http
 POST /scim/Users
 Authorization: Bearer <token>
-Content-Type: application/json
+Content-Type: application/scim+json
 
 {
   "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -246,7 +250,7 @@ Partially update a SCIM resource using RFC 7644 PATCH operations. Publishes doma
 ```http
 PATCH /scim/Users/abc123
 Authorization: Bearer <token>
-Content-Type: application/json
+Content-Type: application/scim+json
 
 {
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
@@ -277,7 +281,7 @@ Replace entire SCIM resource (upsert). Publishes domain events.
 ```http
 PUT /scim/Users/abc123
 Authorization: Bearer <token>
-Content-Type: application/json
+Content-Type: application/scim+json
 
 {
   "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -318,7 +322,7 @@ Perform multiple operations in a single request.
 ```http
 POST /scim/Bulk
 Authorization: Bearer <token>
-Content-Type: application/json
+Content-Type: application/scim+json
 
 {
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],

--- a/packages/two_percent/docs/README.md
+++ b/packages/two_percent/docs/README.md
@@ -11,18 +11,20 @@ TwoPercent is a SCIM 2.0 (System for Cross-domain Identity Management) Rails Eng
 - ✅ PUT (Replace) for Users and Groups
 - ✅ PATCH (Partial Update) with Operations array
 - ✅ DELETE for Users and Groups
+- ✅ GET (Single resource retrieval)
+- ✅ GET with filtering and pagination (List operations)
 - ✅ Bulk operations (bulkId references, continue-on-error)
 - ✅ RFC 7644 Section 3.12 error responses with scimType
 - ✅ Extension schema support
 
 **Not Yet Implemented:**
-- ❌ GET (Single resource retrieval)
-- ❌ GET with filtering, pagination, sorting (List operations)
+- ❌ RFC 7644 `filter` parameter with full SCIM filter expression parsing (simple `query` parameter supported for display_name filtering)
+- ❌ Sorting (sortBy, sortOrder parameters)
 - ❌ ETag support for concurrency control
 - ❌ Discovery endpoints (RFC 7642): /ServiceProviderConfig, /ResourceTypes, /Schemas
 - ❌ Full RFC 7643 schema validation
 
-**Note:** The current release prioritizes write operations required for IdP provisioning. Read operations, filtering, and discovery endpoints are not yet implemented but are on the roadmap for future releases.
+**Note:** The current release supports full CRUD operations for IdP provisioning, including read operations with RFC 7644-compliant ListResponse format. Advanced filtering and discovery endpoints are on the roadmap for future releases.
 
 ## Architecture
 
@@ -57,6 +59,289 @@ graph TD
 - **Domain Events**: TwoPercent publishes domain events when SCIM resources change
 - **Syncable Concern**: Optional helper for syncing SCIM data to your domain models
 - **Direct Model Access**: Query `ScimUser` and `ScimGroup` models directly when needed
+
+## API Endpoints
+
+TwoPercent provides RFC 7644-compliant SCIM 2.0 endpoints for all standard CRUD operations.
+
+### Authentication
+
+All endpoints require authentication via the configured `authenticate` block (see Configuration section). Typically uses HTTP Bearer token authentication.
+
+### Resource Types
+
+**Users:**
+- `POST /scim/Users` - Create user
+- `GET /scim/Users/:id` - Get single user
+- `GET /scim/Users` - List/search users
+- `PATCH /scim/Users/:id` - Update user
+- `PUT /scim/Users/:id` - Replace user
+- `DELETE /scim/Users/:id` - Delete user
+
+**Groups (and subtypes):**
+- `POST /scim/:resource_type` - Create group (Groups, Departments, Territories, Roles, Titles)
+- `GET /scim/:resource_type/:id` - Get single group
+- `GET /scim/:resource_type` - List/search groups
+- `PATCH /scim/:resource_type/:id` - Update group
+- `PUT /scim/:resource_type/:id` - Replace group
+- `DELETE /scim/:resource_type/:id` - Delete group
+
+Where `:resource_type` can be: `Groups`, `Departments`, `Territories`, `Roles`, `Titles`
+
+### GET - Single Resource Retrieval
+
+Retrieve a single SCIM resource by ID.
+
+**Request:**
+```http
+GET /scim/Users/abc123
+Authorization: Bearer <token>
+```
+
+**Response (200 OK):**
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "id": "abc123",
+  "externalId": "user@example.com",
+  "userName": "user@example.com",
+  "name": {
+    "givenName": "John",
+    "familyName": "Doe"
+  },
+  "emails": [
+    {
+      "value": "user@example.com",
+      "primary": true
+    }
+  ],
+  "active": true,
+  "groups": [],
+  "meta": {
+    "resourceType": "User",
+    "created": "2024-01-15T10:30:00Z",
+    "lastModified": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+**Error Response (404 Not Found):**
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "status": "404",
+  "detail": "Resource \"abc123\" not found"
+}
+```
+
+### GET - List/Search Resources
+
+Retrieve multiple resources with optional filtering and pagination. Returns RFC 7644-compliant ListResponse format.
+
+**Request:**
+```http
+GET /scim/Users?query=john&startIndex=1&count=10
+Authorization: Bearer <token>
+```
+
+**Query Parameters:**
+- `query` (optional) - Filter by display_name substring match (case-insensitive)
+- `startIndex` (optional) - 1-based index of first result (default: 1)
+- `count` (optional) - Maximum number of results to return (default: 100, max: 1000)
+
+**Response (200 OK):**
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 42,
+  "startIndex": 1,
+  "itemsPerPage": 10,
+  "Resources": [
+    {
+      "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id": "abc123",
+      "externalId": "user@example.com",
+      "userName": "user@example.com",
+      "displayName": "John Doe",
+      "active": true,
+      "meta": {
+        "resourceType": "User",
+        "created": "2024-01-15T10:30:00Z",
+        "lastModified": "2024-01-15T10:30:00Z"
+      }
+    }
+    // ... more resources
+  ]
+}
+```
+
+**Empty Results:**
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 0,
+  "startIndex": 1,
+  "itemsPerPage": 0,
+  "Resources": []
+}
+```
+
+**Examples:**
+```bash
+# Get all users
+curl -H "Authorization: Bearer <token>" https://your-app.com/scim/Users
+
+# Search users by name
+curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Users?query=john"
+
+# Paginated results
+curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Users?startIndex=11&count=10"
+
+# Get all departments
+curl -H "Authorization: Bearer <token>" https://your-app.com/scim/Departments
+
+# Search territories
+curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Territories?query=west"
+```
+
+### POST - Create Resource
+
+Create a new SCIM resource. Publishes domain events.
+
+**Request:**
+```http
+POST /scim/Users
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "externalId": "user@example.com",
+  "userName": "user@example.com",
+  "name": {
+    "givenName": "John",
+    "familyName": "Doe"
+  },
+  "emails": [
+    {
+      "value": "user@example.com",
+      "primary": true
+    }
+  ],
+  "active": true
+}
+```
+
+**Response (201 Created):**
+- Status: 201 Created
+- Location header: `https://your-app.com/scim/Users/abc123`
+- Body: Full SCIM resource representation
+- Domain Event: `TwoPercent::Domain::Events::UserCreated` published
+
+### PATCH - Update Resource
+
+Partially update a SCIM resource using RFC 7644 PATCH operations. Publishes domain events.
+
+**Request:**
+```http
+PATCH /scim/Users/abc123
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "replace",
+      "path": "active",
+      "value": false
+    },
+    {
+      "op": "replace",
+      "path": "name.givenName",
+      "value": "Jane"
+    }
+  ]
+}
+```
+
+**Response (200 OK):**
+- Body: Updated SCIM resource representation
+- Domain Event: `TwoPercent::Domain::Events::UserUpdated` published
+
+### PUT - Replace Resource
+
+Replace entire SCIM resource (upsert). Publishes domain events.
+
+**Request:**
+```http
+PUT /scim/Users/abc123
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "id": "abc123",
+  "externalId": "user@example.com",
+  "userName": "user@example.com",
+  "active": true
+  // ... full resource
+}
+```
+
+**Response:**
+- Status: 200 OK (if resource existed) or 201 Created (if new)
+- Location header: Set on 201 Created
+- Body: Full SCIM resource representation
+- Domain Event: `UserUpdated` or `UserCreated` published
+
+### DELETE - Delete Resource
+
+Delete a SCIM resource. Publishes domain events.
+
+**Request:**
+```http
+DELETE /scim/Users/abc123
+Authorization: Bearer <token>
+```
+
+**Response (204 No Content):**
+- Status: 204 No Content
+- No body
+- Domain Event: `TwoPercent::Domain::Events::UserDeleted` published
+
+### Bulk Operations
+
+Perform multiple operations in a single request.
+
+**Request:**
+```http
+POST /scim/Bulk
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],
+  "Operations": [
+    {
+      "method": "POST",
+      "path": "/Users",
+      "bulkId": "user1",
+      "data": { /* SCIM user */ }
+    },
+    {
+      "method": "PATCH",
+      "path": "/Users/abc123",
+      "data": { /* PATCH operations */ }
+    }
+  ]
+}
+```
+
+**Response (200 OK):**
+- Contains status for each operation
+- Supports bulkId references between operations
+- See RFC 7644 Section 3.7 for full details
 
 ## Installation
 
@@ -210,8 +495,9 @@ end
 
 ### 3. Direct Model Access
 
-Query `ScimUser` and `ScimGroup` models directly for read-only access to SCIM data:
+Query `ScimUser` and `ScimGroup` models directly for read-only access to SCIM data, or use the GET API endpoints:
 
+**Via ActiveRecord Models:**
 ```ruby
 # Find user by SCIM ID
 scim_user = TwoPercent::ScimUser.find_by_scim_id("user-123")
@@ -228,6 +514,19 @@ attrs = scim_user.to_domain_attributes
 group = TwoPercent::ScimGroup.includes(:scim_users).find_by_scim_id("group-456")
 group.scim_users # => Array of ScimUser records
 ```
+
+**Via GET API Endpoints:**
+```bash
+# Get single resource
+GET /scim/Users/user-123
+
+# List/search resources with pagination and filtering
+GET /scim/Users?query=john&startIndex=1&count=10
+GET /scim/Departments
+GET /scim/Territories?query=west
+```
+
+See the [API Endpoints](#api-endpoints) section for full GET endpoint documentation.
 
 **Available Models:**
 - `TwoPercent::ScimUser` - Stores user SCIM data

--- a/packages/two_percent/docs/README.md
+++ b/packages/two_percent/docs/README.md
@@ -82,15 +82,15 @@ Per RFC 7644, requests should use `Content-Type: application/scim+json`. For bac
 - `PUT /scim/Users/:id` - Replace user
 - `DELETE /scim/Users/:id` - Delete user
 
-**Groups (and subtypes):**
-- `POST /scim/:resource_type` - Create group (Groups, Departments, Territories, Roles, Titles)
+**Groups:**
+- `POST /scim/:resource_type` - Create group (e.g., `/scim/Groups`)
 - `GET /scim/:resource_type/:id` - Get single group
 - `GET /scim/:resource_type` - List/search groups
 - `PATCH /scim/:resource_type/:id` - Update group
 - `PUT /scim/:resource_type/:id` - Replace group
 - `DELETE /scim/:resource_type/:id` - Delete group
 
-Where `:resource_type` can be: `Groups`, `Departments`, `Territories`, `Roles`, `Titles`
+**Note:** By default, only `Groups` is supported. To enable additional custom resource types, configure them in your initializer (see [Configuration](#configuration)).
 
 ### GET - Single Resource Retrieval
 
@@ -201,11 +201,14 @@ curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Users?query=j
 # Paginated results
 curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Users?startIndex=11&count=10"
 
-# Get all departments
-curl -H "Authorization: Bearer <token>" https://your-app.com/scim/Departments
+# Get all groups (works out-of-box)
+curl -H "Authorization: Bearer <token>" https://your-app.com/scim/Groups
 
-# Search territories
-curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Territories?query=west"
+# Search groups by name
+curl -H "Authorization: Bearer <token>" "https://your-app.com/scim/Groups?query=engineering"
+
+# Custom resource types (requires configuration - see Group Resource Types section)
+curl -H "Authorization: Bearer <token>" https://your-app.com/scim/Departments
 ```
 
 ### POST - Create Resource
@@ -368,7 +371,50 @@ Mount the engine in your parent application's `config/routes.rb`:
 mount TwoPercent::Engine => "/scim"
 ```
 
-Configure authentication in `config/initializers/two_percent.rb`.
+## Configuration
+
+Configure TwoPercent in `config/initializers/two_percent.rb`:
+
+### Authentication
+
+Authentication is required for SCIM endpoints. Configure it using the `authenticate` block:
+
+```ruby
+TwoPercent.configure do |config|
+  config.authenticate = ->(*) do
+    authenticate_with_http_token do |token|
+      Token.active.find_by!(token:)
+    end
+  end
+end
+```
+
+See the [Authenticating SCIM requests](#authenticating-scim-requests) section for more details.
+
+### Group Resource Types
+
+By default, TwoPercent supports only the standard SCIM "Groups" resource type. To enable additional company-specific group types, configure them explicitly:
+
+```ruby
+TwoPercent.configure do |config|
+  # Enable custom group types for your organization
+  config.group_resource_types = %w[Groups Departments Territories]
+end
+```
+
+**Default:** `%w[Groups]`
+
+**What this controls:**
+- Which resource types are accepted at `/scim/:resource_type` endpoints
+- All configured types store data in the same `scim_groups` table with a `resource_type` column
+- Domain events include the `resource_type` to distinguish between group types
+
+**Examples of custom group types:**
+You can define any resource types that fit your organization's structure, such as:
+- `Departments` - Organizational departments
+- `Territories` - Geographic regions or sales territories
+
+All configured types support the full CRUD API (POST/PUT/PATCH/DELETE/GET).
 
 ## Integration
 
@@ -526,15 +572,18 @@ GET /scim/Users/user-123
 
 # List/search resources with pagination and filtering
 GET /scim/Users?query=john&startIndex=1&count=10
+GET /scim/Groups
+GET /scim/Groups?query=engineering
+
+# Custom resource types (requires configuration)
 GET /scim/Departments
-GET /scim/Territories?query=west
 ```
 
 See the [API Endpoints](#api-endpoints) section for full GET endpoint documentation.
 
 **Available Models:**
 - `TwoPercent::ScimUser` - Stores user SCIM data
-- `TwoPercent::ScimGroup` - Stores group SCIM data (departments, territories, roles, etc.)
+- `TwoPercent::ScimGroup` - Stores group SCIM data (Groups and any configured custom types)
 
 ## Authenticating SCIM requests
 

--- a/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    two_percent (1.0.0)
+    two_percent (1.1.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    two_percent (1.0.0)
+    two_percent (1.1.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/lib/two_percent/configuration.rb
+++ b/packages/two_percent/lib/two_percent/configuration.rb
@@ -54,6 +54,26 @@ module TwoPercent
   config_accessor :logger
 
   #
+  # Group resource types that TwoPercent will accept and process.
+  # Defaults to ["Groups"] which is the standard SCIM 2.0 group resource type.
+  #
+  # To support additional company-specific group types (like Departments, Territories),
+  # add them to this array in your initializer:
+  #
+  #   TwoPercent.configure do |config|
+  #     config.group_resource_types = %w[Groups Departments Territories]
+  #   end
+  #
+  # All configured types will:
+  # - Accept POST/PUT/PATCH/DELETE/GET operations at /scim/:resource_type
+  # - Store data in the same scim_groups table with resource_type column
+  # - Publish domain events with the resource_type included
+  #
+  config_accessor :group_resource_types do
+    %w[Groups]
+  end
+
+  #
   # HTTP header name for correlation ID tracking
   # Defaults to "X-Correlation-Id" (common microservices pattern)
   # Set to your IdP's correlation header (e.g., "SCIM-Request-ID")

--- a/packages/two_percent/lib/two_percent/version.rb
+++ b/packages/two_percent/lib/two_percent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TwoPercent
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/packages/two_percent/spec/dummy/config/initializers/two_percent.rb
+++ b/packages/two_percent/spec/dummy/config/initializers/two_percent.rb
@@ -4,5 +4,8 @@ Rails.application.config.to_prepare do
   TwoPercent.configure do |config|
     # Authentication configuration (allow all for tests)
     config.authenticate = ->(*) { true }
+
+    # Enable all group resource types for comprehensive test coverage
+    config.group_resource_types = %w[Groups Departments Territories Roles Titles]
   end
 end

--- a/packages/two_percent/spec/requests/scim_controller_spec.rb
+++ b/packages/two_percent/spec/requests/scim_controller_spec.rb
@@ -908,6 +908,362 @@ RSpec.describe "SCIM API", type: :request do
     end
   end
 
+  # ========== GET /scim/Users/:id (Retrieve Single User) ==========
+  describe "GET /scim/Users/:id" do
+    let!(:existing_user) do
+      create_scim_user(
+        scim_id: "get-user-123",
+        display_name: "John Doe",
+        email: "john@example.com"
+      )
+    end
+
+    context "when user exists" do
+      it "returns 200 OK" do
+        get "/scim/Users/get-user-123", headers: headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns SCIM User resource with correct schemas" do
+        get "/scim/Users/get-user-123", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:schemas:core:2.0:User")
+      end
+
+      it "returns user with id and meta" do
+        get "/scim/Users/get-user-123", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["id"]).to eq("get-user-123")
+        expect(json_response["displayName"]).to eq("John Doe")
+        expect(json_response["meta"]).to be_present
+        expect(json_response["meta"]["resourceType"]).to eq("User")
+      end
+
+      it "includes created and lastModified timestamps in meta" do
+        get "/scim/Users/get-user-123", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["meta"]["created"]).to be_present
+        expect(json_response["meta"]["lastModified"]).to be_present
+      end
+
+      it "does not publish domain events (read-only)" do
+        get "/scim/Users/get-user-123", headers: headers
+
+        expect(published_events).to be_empty
+      end
+    end
+
+    context "when user does not exist" do
+      it "returns 404 Not Found" do
+        get "/scim/Users/nonexistent-user", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns RFC 7644 error response" do
+        get "/scim/Users/nonexistent-user", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:Error")
+        expect(json_response["scimType"]).to eq("noTarget")
+      end
+    end
+  end
+
+  # ========== GET /scim/Groups/:id (Retrieve Single Group) ==========
+  describe "GET /scim/Groups/:id" do
+    let!(:user1) { create_scim_user(scim_id: "member-1", display_name: "Alice") }
+    let!(:user2) { create_scim_user(scim_id: "member-2", display_name: "Bob") }
+    let!(:existing_group) do
+      group = create_scim_group(
+        scim_id: "get-group-456",
+        display_name: "Engineering Team",
+        resource_type: "Groups"
+      )
+      TwoPercent::ScimGroupMembership.create!(scim_user: user1, scim_group: group)
+      TwoPercent::ScimGroupMembership.create!(scim_user: user2, scim_group: group)
+      group
+    end
+
+    context "when group exists" do
+      it "returns 200 OK" do
+        get "/scim/Groups/get-group-456", headers: headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns SCIM Group resource with correct schemas" do
+        get "/scim/Groups/get-group-456", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:schemas:core:2.0:Group")
+      end
+
+      it "returns group with members" do
+        get "/scim/Groups/get-group-456", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["id"]).to eq("get-group-456")
+        expect(json_response["displayName"]).to eq("Engineering Team")
+        expect(json_response["members"]).to be_an(Array)
+        expect(json_response["members"].size).to eq(2)
+      end
+
+      it "includes meta with resourceType" do
+        get "/scim/Groups/get-group-456", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["meta"]["resourceType"]).to eq("Groups")
+      end
+    end
+
+    context "when group does not exist" do
+      it "returns 404 Not Found" do
+        get "/scim/Groups/nonexistent-group", headers: headers
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  # ========== GET /scim/Departments/:id (Retrieve Single Department) ==========
+  describe "GET /scim/Departments/:id" do
+    let!(:department) do
+      create_scim_group(
+        scim_id: "dept-789",
+        display_name: "Sales Department",
+        resource_type: "Departments"
+      )
+    end
+
+    it "returns department with correct resource_type in meta" do
+      get "/scim/Departments/dept-789", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      json_response = JSON.parse(response.body)
+      expect(json_response["meta"]["resourceType"]).to eq("Departments")
+    end
+  end
+
+  # ========== GET /scim/Users (List Users with RFC 7644 ListResponse) ==========
+  describe "GET /scim/Users" do
+    let!(:user1) { create_scim_user(scim_id: "list-user-1", display_name: "Alice Anderson") }
+    let!(:user2) { create_scim_user(scim_id: "list-user-2", display_name: "Bob Brown") }
+    let!(:user3) { create_scim_user(scim_id: "list-user-3", display_name: "Charlie Chen") }
+
+    context "without query parameters" do
+      it "returns 200 OK" do
+        get "/scim/Users", headers: headers
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns RFC 7644 ListResponse format" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:ListResponse")
+        expect(json_response).to have_key("totalResults")
+        expect(json_response).to have_key("startIndex")
+        expect(json_response).to have_key("itemsPerPage")
+        expect(json_response).to have_key("Resources")
+      end
+
+      it "returns all users in Resources array" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(3)
+        expect(json_response["Resources"]).to be_an(Array)
+        expect(json_response["Resources"].size).to eq(3)
+      end
+
+      it "returns users with full SCIM representation" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        first_user = json_response["Resources"].first
+        expect(first_user["schemas"]).to include("urn:ietf:params:scim:schemas:core:2.0:User")
+        expect(first_user["id"]).to be_present
+        expect(first_user["displayName"]).to be_present
+        expect(first_user["meta"]).to be_present
+      end
+
+      it "defaults startIndex to 1" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["startIndex"]).to eq(1)
+      end
+
+      it "does not publish domain events (read-only)" do
+        get "/scim/Users", headers: headers
+
+        expect(published_events).to be_empty
+      end
+    end
+
+    context "with pagination parameters" do
+      it "respects count parameter" do
+        get "/scim/Users?count=2", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(3)
+        expect(json_response["itemsPerPage"]).to eq(2)
+        expect(json_response["Resources"].size).to eq(2)
+      end
+
+      it "respects startIndex parameter (1-based)" do
+        get "/scim/Users?startIndex=2&count=2", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["startIndex"]).to eq(2)
+        expect(json_response["Resources"].size).to eq(2)
+        # Should skip first user
+        expect(json_response["Resources"].map { |u| u["id"] }).not_to include("list-user-1")
+      end
+
+      it "handles startIndex beyond results" do
+        get "/scim/Users?startIndex=100", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(3)
+        expect(json_response["Resources"]).to eq([])
+        expect(json_response["itemsPerPage"]).to eq(0)
+      end
+
+      it "enforces maximum count limit" do
+        get "/scim/Users?count=10000", headers: headers
+
+        json_response = JSON.parse(response.body)
+        # Should cap at maximum (1000)
+        expect(json_response["itemsPerPage"]).to be <= 1000
+      end
+    end
+
+    context "with query filter parameter" do
+      it "filters by display_name substring match" do
+        get "/scim/Users?query=Alice", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(1)
+        expect(json_response["Resources"].first["displayName"]).to eq("Alice Anderson")
+      end
+
+      it "is case-insensitive" do
+        get "/scim/Users?query=alice", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(1)
+      end
+
+      it "returns empty array when no matches" do
+        get "/scim/Users?query=Nonexistent", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(0)
+        expect(json_response["Resources"]).to eq([])
+      end
+
+      it "combines query with pagination" do
+        get "/scim/Users?query=n&count=1", headers: headers
+
+        json_response = JSON.parse(response.body)
+        # Should match "Anderson", "Brown", "Chen" (3 total)
+        expect(json_response["totalResults"]).to eq(3)
+        expect(json_response["itemsPerPage"]).to eq(1)
+        expect(json_response["Resources"].size).to eq(1)
+      end
+    end
+
+    context "with empty results" do
+      before do
+        TwoPercent::ScimUser.delete_all
+      end
+
+      it "returns empty Resources array" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(0)
+        expect(json_response["Resources"]).to eq([])
+        expect(json_response["itemsPerPage"]).to eq(0)
+      end
+
+      it "maintains RFC 7644 format" do
+        get "/scim/Users", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:ListResponse")
+      end
+    end
+  end
+
+  # ========== GET /scim/Groups (List Groups with RFC 7644 ListResponse) ==========
+  describe "GET /scim/Groups" do
+    let!(:group1) { create_scim_group(scim_id: "list-group-1", display_name: "Engineering", resource_type: "Groups") }
+    let!(:group2) { create_scim_group(scim_id: "list-group-2", display_name: "Marketing", resource_type: "Groups") }
+
+    it "returns RFC 7644 ListResponse format" do
+      get "/scim/Groups", headers: headers
+
+      json_response = JSON.parse(response.body)
+      expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:ListResponse")
+      expect(json_response["totalResults"]).to eq(2)
+      expect(json_response["Resources"]).to be_an(Array)
+    end
+
+    it "filters by query parameter" do
+      get "/scim/Groups?query=Engineer", headers: headers
+
+      json_response = JSON.parse(response.body)
+      expect(json_response["totalResults"]).to eq(1)
+      expect(json_response["Resources"].first["displayName"]).to eq("Engineering")
+    end
+  end
+
+  # ========== GET /scim/Departments (List Departments) ==========
+  describe "GET /scim/Departments" do
+    let!(:dept1) { create_scim_group(scim_id: "dept-1", display_name: "Sales", resource_type: "Departments") }
+    let!(:dept2) { create_scim_group(scim_id: "dept-2", display_name: "Support", resource_type: "Departments") }
+    let!(:group) { create_scim_group(scim_id: "other-1", display_name: "Other Group", resource_type: "Groups") }
+
+    it "returns only Departments resource_type" do
+      get "/scim/Departments", headers: headers
+
+      json_response = JSON.parse(response.body)
+      expect(json_response["totalResults"]).to eq(2)
+      json_response["Resources"].each do |resource|
+        expect(resource["meta"]["resourceType"]).to eq("Departments")
+      end
+    end
+
+    it "does not include other resource types" do
+      get "/scim/Departments", headers: headers
+
+      json_response = JSON.parse(response.body)
+      resource_ids = json_response["Resources"].map { |r| r["id"] }
+      expect(resource_ids).not_to include("other-1")
+    end
+  end
+
+  # ========== GET /scim/Territories (List Territories) ==========
+  describe "GET /scim/Territories" do
+    let!(:territory) { create_scim_group(scim_id: "terr-1", display_name: "Northeast", resource_type: "Territories") }
+
+    it "returns only Territories resource_type" do
+      get "/scim/Territories", headers: headers
+
+      json_response = JSON.parse(response.body)
+      expect(json_response["totalResults"]).to eq(1)
+      expect(json_response["Resources"].first["meta"]["resourceType"]).to eq("Territories")
+    end
+  end
+
   # Test helpers
   def create_scim_user(attributes = {})
     scim_id = attributes[:scim_id] || "user-#{SecureRandom.hex(4)}"

--- a/packages/two_percent/spec/requests/scim_controller_spec.rb
+++ b/packages/two_percent/spec/requests/scim_controller_spec.rb
@@ -1310,6 +1310,33 @@ RSpec.describe "SCIM API", type: :request do
     end
   end
 
+  # ========== GET with Invalid Resource Types (Validation) ==========
+  describe "GET with invalid resource type" do
+    context "GET /scim/:resource_type/:id (show)" do
+      it "returns 400 Bad Request for unknown resource type" do
+        get "/scim/InvalidType/some-id", headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:Error")
+        expect(json_response["detail"]).to eq("Unknown resource type: InvalidType")
+      end
+    end
+
+    context "GET /scim/:resource_type (index)" do
+      it "returns 400 Bad Request for unknown resource type" do
+        get "/scim/InvalidType", headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:Error")
+        expect(json_response["detail"]).to eq("Unknown resource type: InvalidType")
+      end
+    end
+  end
+
   # Test helpers
   def create_scim_user(attributes = {})
     scim_id = attributes[:scim_id] || "user-#{SecureRandom.hex(4)}"

--- a/packages/two_percent/spec/requests/scim_controller_spec.rb
+++ b/packages/two_percent/spec/requests/scim_controller_spec.rb
@@ -1178,6 +1178,14 @@ RSpec.describe "SCIM API", type: :request do
         expect(json_response["itemsPerPage"]).to eq(1)
         expect(json_response["Resources"].size).to eq(1)
       end
+
+      it "escapes LIKE wildcards in query parameter" do
+        # Verify wildcards are treated as literals, not pattern operators
+        get "/scim/Users?query=#{CGI.escape('_')}", headers: headers
+
+        json_response = JSON.parse(response.body)
+        expect(json_response["totalResults"]).to eq(0) # No matches (not single-char wildcard)
+      end
     end
 
     context "with empty results" do

--- a/packages/two_percent/spec/requests/scim_controller_spec.rb
+++ b/packages/two_percent/spec/requests/scim_controller_spec.rb
@@ -906,6 +906,44 @@ RSpec.describe "SCIM API", type: :request do
       expect(response).to have_http_status(:created)
       expect(TwoPercent::ScimGroup.last.resource_type).to eq("Titles")
     end
+
+    context "with unknown resource type" do
+      it "returns 400 Bad Request with error message" do
+        post "/scim/UnknownType", params: valid_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+
+        json = JSON.parse(response.body)
+        expect(json["schemas"]).to include("urn:ietf:params:scim:api:messages:2.0:Error")
+        expect(json["detail"]).to eq("Unknown resource type: UnknownType")
+      end
+    end
+
+    context "with custom group_resource_types configuration" do
+      before do
+        @original_config = TwoPercent.config.group_resource_types
+        TwoPercent.config.group_resource_types = %w[Groups Teams]
+      end
+
+      after do
+        TwoPercent.config.group_resource_types = @original_config
+      end
+
+      it "accepts configured resource types" do
+        post "/scim/Teams", params: valid_payload.to_json, headers: headers
+        expect(response).to have_http_status(:created)
+        expect(TwoPercent::ScimGroup.last.resource_type).to eq("Teams")
+      end
+
+      it "rejects non-configured resource types" do
+        post "/scim/Departments", params: valid_payload.to_json, headers: headers
+
+        expect(response).to have_http_status(:bad_request)
+
+        json = JSON.parse(response.body)
+        expect(json["detail"]).to eq("Unknown resource type: Departments")
+      end
+    end
   end
 
   # ========== GET /scim/Users/:id (Retrieve Single User) ==========


### PR DESCRIPTION
This PR adds the following:

**New Endpoints:**
- `GET /scim/:resource_type/:id` - Single resource retrieval
- `GET /scim/:resource_type` - List/search with pagination and filtering

**Features:**
- RFC 7644 ListResponse format: `{schemas, totalResults, startIndex, itemsPerPage, Resources}`
- SCIM pagination: `?startIndex=` (1-based) and `?count=` (default: 100, max: 1000)
- Query filtering: `?query=` for case-insensitive display_name substring matching

---

The ticket for this PR is [here](https://runway.powerhrg.com/backlog_items/SHD-1901).