### PR TITLE
[SHD-1918] - Calculate Checksum With Permission Data

### DIFF
--- a/packages/consent/lib/consent.rb
+++ b/packages/consent/lib/consent.rb
@@ -90,7 +90,8 @@ module Consent
   def self.subjects_checksum
     require "digest/sha2"
 
-    Digest::SHA256.hexdigest(Consent.subjects.sort.map(&:to_permission_payload).to_json)
+    subjects = Consent.subjects.sort
+    Digest::SHA256.hexdigest(subjects.map(&:to_permission_payload).to_json)
   end
 
   # Defines a subject with the given key, label and options

--- a/packages/consent/lib/consent.rb
+++ b/packages/consent/lib/consent.rb
@@ -84,24 +84,13 @@ module Consent
     Dir[*permission_files].each { |file| Kernel.load(file) }
   end
 
-  # Returns the concatenated contents of all permission files
+  # Calculates a deterministic checksum of all permission definitions
   #
-  # @param paths [Array<String,#to_s>] paths where the ruby files are located
-  # @return [String] concatenated file contents
-  def self.subjects_content(paths)
-    permission_files = paths.map { |dir| File.join(dir, "*.rb") }
-    files = Dir[*permission_files].sort
-    files.map { |file| File.read(file) }.join
-  end
-
-  # Calculates a deterministic checksum of all permission files
-  #
-  # @param paths [Array<String,#to_s>] paths where the ruby files are located
-  # @return [String] SHA256 hexdigest of all permission file contents
-  def self.subjects_checksum(paths)
+  # @return [String] SHA256 hexdigest of all permission definitions
+  def self.subjects_checksum
     require "digest/sha2"
 
-    Digest::SHA256.hexdigest(subjects_content(paths))
+    Digest::SHA256.hexdigest(Consent.subjects.sort_by(&:key).map(&:to_permission_payload))
   end
 
   # Defines a subject with the given key, label and options

--- a/packages/consent/lib/consent.rb
+++ b/packages/consent/lib/consent.rb
@@ -90,7 +90,7 @@ module Consent
   def self.subjects_checksum
     require "digest/sha2"
 
-    Digest::SHA256.hexdigest(Consent.subjects.sort_by(&:key).map(&:to_permission_payload))
+    Digest::SHA256.hexdigest(Consent.subjects.sort.map(&:to_permission_payload).to_json)
   end
 
   # Defines a subject with the given key, label and options

--- a/packages/consent/lib/consent/action.rb
+++ b/packages/consent/lib/consent/action.rb
@@ -25,9 +25,13 @@ module Consent
       {
         action: key,
         label: label,
-        views: views.values.sort_by(&:key).map(&:to_permission_payload),
+        views: views.values.sort.map(&:to_permission_payload),
         default_view: default_view&.to_permission_payload,
       }
+    end
+
+    def <=>(other)
+      key <=> other.key
     end
   end
 end

--- a/packages/consent/lib/consent/action.rb
+++ b/packages/consent/lib/consent/action.rb
@@ -25,7 +25,7 @@ module Consent
       {
         action: key,
         label: label,
-        views: views.values.map(&:to_permission_payload),
+        views: views.values.sort_by(&:key).map(&:to_permission_payload),
         default_view: default_view&.to_permission_payload,
       }
     end

--- a/packages/consent/lib/consent/action.rb
+++ b/packages/consent/lib/consent/action.rb
@@ -22,10 +22,11 @@ module Consent
     end
 
     def to_permission_payload
+      views = self.views.values.sort
       {
         action: key,
         label: label,
-        views: views.values.sort.map(&:to_permission_payload),
+        views: views.map(&:to_permission_payload),
         default_view: default_view&.to_permission_payload,
       }
     end

--- a/packages/consent/lib/consent/action.rb
+++ b/packages/consent/lib/consent/action.rb
@@ -27,6 +27,7 @@ module Consent
         action: key,
         label: label,
         views: views.map(&:to_permission_payload),
+        options: options.except(:views),
         default_view: default_view&.to_permission_payload,
       }
     end

--- a/packages/consent/lib/consent/permission_definition_payload.rb
+++ b/packages/consent/lib/consent/permission_definition_payload.rb
@@ -5,7 +5,7 @@ module Consent
     def self.generate
       {
         consent_version: Consent::VERSION,
-        permissions: Consent.subjects.map(&:to_permission_payload),
+        permissions: Consent.subjects.sort_by(&:key).map(&:to_permission_payload),
       }
     end
   end

--- a/packages/consent/lib/consent/permission_definition_payload.rb
+++ b/packages/consent/lib/consent/permission_definition_payload.rb
@@ -3,9 +3,10 @@
 module Consent
   class PermissionDefinitionPayload
     def self.generate
+      subjects = Consent.subjects.sort
       {
         consent_version: Consent::VERSION,
-        permissions: Consent.subjects.sort.map(&:to_permission_payload),
+        permissions: subjects.map(&:to_permission_payload),
       }
     end
   end

--- a/packages/consent/lib/consent/permission_definition_payload.rb
+++ b/packages/consent/lib/consent/permission_definition_payload.rb
@@ -5,7 +5,7 @@ module Consent
     def self.generate
       {
         consent_version: Consent::VERSION,
-        permissions: Consent.subjects.sort_by(&:key).map(&:to_permission_payload),
+        permissions: Consent.subjects.sort.map(&:to_permission_payload),
       }
     end
   end

--- a/packages/consent/lib/consent/subject.rb
+++ b/packages/consent/lib/consent/subject.rb
@@ -15,9 +15,15 @@ module Consent
       {
         subject: key,
         label: label,
-        actions: actions.sort_by(&:key).map(&:to_permission_payload),
-        views: views.values.sort_by(&:key).map(&:to_permission_payload),
+        actions: actions.sort.map(&:to_permission_payload),
+        views: views.values.sort.map(&:to_permission_payload),
       }
+    end
+
+    def <=>(other)
+      key = Consent::SubjectCoder.dump(key)
+      other_key = Consent::SubjectCoder.dump(other.key)
+      key <=> other_key
     end
   end
 end

--- a/packages/consent/lib/consent/subject.rb
+++ b/packages/consent/lib/consent/subject.rb
@@ -12,11 +12,13 @@ module Consent
     end
 
     def to_permission_payload
+      actions = self.actions.sort
+      views = self.views.values.sort
       {
         subject: key,
         label: label,
-        actions: actions.sort.map(&:to_permission_payload),
-        views: views.values.sort.map(&:to_permission_payload),
+        actions: actions.map(&:to_permission_payload),
+        views: views.map(&:to_permission_payload),
       }
     end
 

--- a/packages/consent/lib/consent/subject.rb
+++ b/packages/consent/lib/consent/subject.rb
@@ -15,8 +15,8 @@ module Consent
       {
         subject: key,
         label: label,
-        actions: actions.map(&:to_permission_payload),
-        views: views.values.map(&:to_permission_payload),
+        actions: actions.sort_by(&:key).map(&:to_permission_payload),
+        views: views.values.sort_by(&:key).map(&:to_permission_payload),
       }
     end
   end

--- a/packages/consent/lib/consent/view.rb
+++ b/packages/consent/lib/consent/view.rb
@@ -29,5 +29,9 @@ module Consent
         label: label,
       }
     end
+
+    def <=>(other)
+      key <=> other.key
+    end
   end
 end

--- a/packages/consent/spec/consent/action_spec.rb
+++ b/packages/consent/spec/consent/action_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Consent::Action do
                                                    action: :key,
                                                    label: "Label",
                                                    views: action.views.values.map(&:to_permission_payload),
+                                                   options: {},
                                                    default_view: nil,
                                                  })
     end

--- a/packages/consent/spec/consent_spec.rb
+++ b/packages/consent/spec/consent_spec.rb
@@ -46,7 +46,8 @@ describe Consent do
   describe ".subjects_checksum" do
     it "returns SHA256 hexdigest of permission definitions" do
       checksum = Consent.subjects_checksum
-      subjects_checksum = Digest::SHA256.hexdigest(Consent.subjects.sort.map(&:to_permission_payload).to_json)
+      subjects = Consent.subjects.sort
+      subjects_checksum = Digest::SHA256.hexdigest(subjects.map(&:to_permission_payload).to_json)
 
       expect(checksum).to eq(subjects_checksum)
     end

--- a/packages/consent/spec/consent_spec.rb
+++ b/packages/consent/spec/consent_spec.rb
@@ -73,40 +73,19 @@ describe Consent do
   end
 
   describe ".subjects_checksum" do
-    it "returns SHA256 hexdigest of permission file contents" do
-      dir = Dir.mktmpdir
-      File.write(File.join(dir, "test.rb"), "test content")
+    it "returns SHA256 hexdigest of permission definitions" do
+      checksum = Consent.subjects_checksum
+      subjects_checksum = Digest::SHA256.hexdigest(Consent.subjects.sort_by(&:key).map(&:to_permission_payload))
 
-      checksum = Consent.subjects_checksum([dir])
-
-      expect(checksum).to eq(Digest::SHA256.hexdigest("test content"))
-
-      FileUtils.rm_rf(dir)
-    end
-
-    it "returns same checksum for same content" do
-      dir = Dir.mktmpdir
-      File.write(File.join(dir, "test.rb"), "test content")
-
-      checksum1 = Consent.subjects_checksum([dir])
-      checksum2 = Consent.subjects_checksum([dir])
-
-      expect(checksum1).to eq(checksum2)
-
-      FileUtils.rm_rf(dir)
+      expect(checksum).to eq(subjects_checksum)
     end
 
     it "returns different checksum when content changes" do
-      dir = Dir.mktmpdir
-      File.write(File.join(dir, "test.rb"), "original content")
-      checksum1 = Consent.subjects_checksum([dir])
+      subjects_checksum1 = Consent.subjects_checksum
+      Consent.subjects.last.actions << Consent::Action.new(Consent.subjects.last, :new_action, "New Action")
+      subjects_checksum2 = Consent.subjects_checksum
 
-      File.write(File.join(dir, "test.rb"), "modified content")
-      checksum2 = Consent.subjects_checksum([dir])
-
-      expect(checksum1).not_to eq(checksum2)
-
-      FileUtils.rm_rf(dir)
+      expect(subjects_checksum1).not_to eq(subjects_checksum2)
     end
   end
 end

--- a/packages/consent/spec/consent_spec.rb
+++ b/packages/consent/spec/consent_spec.rb
@@ -43,39 +43,10 @@ describe Consent do
     end
   end
 
-  describe ".subjects_content" do
-    it "returns concatenated contents of all permission files" do
-      dir = Dir.mktmpdir
-      File.write(File.join(dir, "file1.rb"), "# File 1\nConsent.define :test1")
-      File.write(File.join(dir, "file2.rb"), "# File 2\nConsent.define :test2")
-
-      content = Consent.subjects_content([dir])
-
-      expect(content).to include("# File 1")
-      expect(content).to include("# File 2")
-      expect(content).to include("Consent.define :test1")
-      expect(content).to include("Consent.define :test2")
-
-      FileUtils.rm_rf(dir)
-    end
-
-    it "returns files in sorted order for deterministic results" do
-      dir = Dir.mktmpdir
-      File.write(File.join(dir, "z_last.rb"), "LAST")
-      File.write(File.join(dir, "a_first.rb"), "FIRST")
-
-      content = Consent.subjects_content([dir])
-
-      expect(content.index("FIRST")).to be < content.index("LAST")
-
-      FileUtils.rm_rf(dir)
-    end
-  end
-
   describe ".subjects_checksum" do
     it "returns SHA256 hexdigest of permission definitions" do
       checksum = Consent.subjects_checksum
-      subjects_checksum = Digest::SHA256.hexdigest(Consent.subjects.sort_by(&:key).map(&:to_permission_payload))
+      subjects_checksum = Digest::SHA256.hexdigest(Consent.subjects.sort.map(&:to_permission_payload).to_json)
 
       expect(checksum).to eq(subjects_checksum)
     end


### PR DESCRIPTION
This PR changes the calculation for permission checksums to use permission definition data instead of permission file contents.