### PR TITLE
[SHD-1923] Add v1.x.x SCIM models

### DIFF
--- a/packages/two_percent/Gemfile.lock
+++ b/packages/two_percent/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    two_percent (0.5.0)
+    two_percent (0.6.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/app/models/two_percent/application_record.rb
+++ b/packages/two_percent/app/models/two_percent/application_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TwoPercent
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+module TwoPercent
+  class ScimGroup < ApplicationRecord
+    self.table_name = "two_percent_scim_groups"
+    serialize :scim_data, coder: JSON
+
+    has_many :scim_group_memberships, class_name: "TwoPercent::ScimGroupMembership",
+                                      foreign_key: :scim_group_id, dependent: :destroy
+    has_many :scim_users, through: :scim_group_memberships
+
+    validates :scim_id, presence: true, uniqueness: true
+    validates :external_id, presence: true
+    validates :display_name, presence: true
+    validates :resource_type, presence: true
+    validates :scim_data, presence: true
+
+    scope :active, -> { where(active: true) }
+    scope :by_resource_type, ->(type) { where(resource_type: type) }
+
+    # Creates or updates a group from SCIM data
+    #
+    # Generates a UUID for the id field if not present (for POST/create operations).
+    # Validates the SCIM data against the Group schema before persisting.
+    #
+    # @param resource_type [String] The resource type (e.g., "Groups", "Departments", "Territories")
+    # @param scim_hash [Hash] SCIM Group resource hash conforming to RFC 7643
+    # @param correlation_id [String, nil] Optional correlation ID for tracking
+    #   changes across network hops (e.g., App A -> App B -> App C)
+    # @return [TwoPercent::ScimGroup] The persisted group record
+    # @raise [TwoPercent::Scim::ValidationError] If SCIM data fails schema validation
+    def self.upsert_from_scim(resource_type, scim_hash, correlation_id: nil)
+      # Generate ID if not present (for POST/create operations)
+      scim_hash = scim_hash.dup
+      scim_hash["id"] ||= SecureRandom.uuid
+
+      validated_data = TwoPercent::Scim::Schema.validate_group(scim_hash, require_id: true)
+      scim_group = find_or_initialize_by(scim_id: scim_hash["id"])
+      scim_group.update_from_scim!(resource_type, validated_data, correlation_id: correlation_id)
+
+      scim_group.replace_members(scim_hash["members"], correlation_id) if scim_hash.key?("members")
+
+      scim_group
+    end
+
+    def self.find_by_scim_id(scim_id)
+      find_by(scim_id: scim_id)
+    end
+
+    def self.exists_by_scim_id?(scim_id)
+      exists?(scim_id: scim_id)
+    end
+
+    def self.destroy_by_scim_id(scim_id)
+      find_by_scim_id(scim_id)&.destroy
+    end
+
+    # Extracts domain attributes for publishing in domain events
+    #
+    # Returns key attributes for event payloads.
+    # @return [Hash] Domain attributes
+    def to_domain_attributes
+      {
+        scim_id: scim_id,
+        external_id: external_id,
+        display_name: display_name,
+        resource_type: resource_type,
+        active: active,
+      }.compact
+    end
+
+    # Returns full SCIM representation for HTTP responses
+    #
+    # @return [Hash] RFC 7644 compliant SCIM Group resource
+    def to_scim_representation
+      representation = scim_data.merge(
+        "id" => scim_id,
+        "meta" => {
+          "resourceType" => resource_type,
+          "created" => created_at.iso8601,
+          "lastModified" => updated_at.iso8601,
+        }
+      )
+
+      representation["members"] = members_representation if scim_users.loaded?
+      representation
+    end
+
+    def update_from_scim!(resource_type, validated_data, correlation_id: nil)
+      core_data = validated_data[:core]
+      self.scim_data = core_data.merge(validated_data[:extensions])
+      self.scim_id = core_data["id"]
+      self.external_id = core_data["externalId"]
+      self.display_name = core_data["displayName"]
+      self.resource_type = resource_type
+
+      extension_data = validated_data[:extensions]
+      self.active = extension_data.dig("urn:ietf:params:scim:schemas:extension:authservice:2.0:Group",
+                                       "active") != false
+      self.correlation_id = correlation_id
+      save!
+    end
+
+    def replace_members(members_array, correlation_id)
+      member_scim_ids = members_array.filter_map { |m| m["value"] }
+      existing_users = validate_users_exist!(member_scim_ids)
+      existing_user_ids = scim_group_memberships.pluck(:scim_user_id)
+
+      users_to_add = existing_users.where.not(id: existing_user_ids)
+      bulk_insert_memberships(users_to_add, correlation_id) if users_to_add.any?
+
+      # Bulk delete removed memberships
+      users_to_remove_ids = scim_users.where.not(scim_id: member_scim_ids).pluck(:id)
+      scim_group_memberships.where(scim_user_id: users_to_remove_ids).delete_all
+    end
+
+    # Extracts a nested attribute from the scim_data JSON
+    #
+    # @param path [String] Dot-separated path to the attribute (e.g., "displayName")
+    # @return [Object, nil] The attribute value or nil if not found
+    # @example
+    #   group.scim_attribute("members.0.value") # => "user-id-123"
+    def scim_attribute(path)
+      keys = path.split(".")
+      scim_data.dig(*keys)
+    end
+
+  private
+
+    # Validates that all user IDs exist in the database
+    #
+    # @param member_scim_ids [Array<String>] Array of SCIM user IDs to validate
+    # @return [ActiveRecord::Relation] The existing users
+    # @raise [ArgumentError] If any users do not exist
+    def validate_users_exist!(member_scim_ids)
+      existing_users = TwoPercent::ScimUser.where(scim_id: member_scim_ids)
+      missing_ids = member_scim_ids - existing_users.pluck(:scim_id)
+
+      if missing_ids.any?
+        raise ArgumentError,
+              "Cannot add non-existent users to group: #{missing_ids.join(', ')}"
+      end
+
+      existing_users
+    end
+
+    # Bulk insert memberships for performance
+    #
+    # @param users_to_add [ActiveRecord::Relation] Users to add as members
+    # @param correlation_id [String, nil] Correlation ID for tracking
+    def bulk_insert_memberships(users_to_add, correlation_id)
+      membership_records = users_to_add.pluck(:id).map do |user_id|
+        {
+          scim_user_id: user_id,
+          scim_group_id: id,
+          correlation_id: correlation_id,
+          created_at: Time.current,
+          updated_at: Time.current,
+        }
+      end
+
+      # Skip duplicates (handles race conditions and migration scenarios)
+      TwoPercent::ScimGroupMembership.insert_all(
+        membership_records,
+        unique_by: %i[scim_user_id scim_group_id]
+      )
+    end
+
+    # Build SCIM members representation
+    #
+    # @return [Array<Hash>] Array of member references
+    def members_representation
+      scim_users.map do |user|
+        {
+          "value" => user.scim_id,
+          "display" => user.display_name,
+          "$ref" => "Users/#{user.scim_id}",
+        }
+      end
+    end
+  end
+end

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -107,7 +107,7 @@ module TwoPercent
       existing_user_ids = scim_group_memberships.pluck(:scim_user_id)
 
       users_to_add = existing_users.where.not(id: existing_user_ids)
-      bulk_insert_memberships(users_to_add, correlation_id) if users_to_add.any?
+      bulk_insert_memberships(users_to_add) if users_to_add.any?
 
       # Bulk delete removed memberships
       users_to_remove_ids = scim_users.where.not(scim_id: member_scim_ids).pluck(:id)
@@ -147,13 +147,11 @@ module TwoPercent
     # Bulk insert memberships for performance
     #
     # @param users_to_add [ActiveRecord::Relation] Users to add as members
-    # @param correlation_id [String, nil] Correlation ID for tracking
-    def bulk_insert_memberships(users_to_add, correlation_id)
+    def bulk_insert_memberships(users_to_add)
       membership_records = users_to_add.pluck(:id).map do |user_id|
         {
           scim_user_id: user_id,
           scim_group_id: id,
-          correlation_id: correlation_id,
           created_at: Time.current,
           updated_at: Time.current,
         }

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -10,7 +10,7 @@ module TwoPercent
     has_many :scim_users, through: :scim_group_memberships
 
     validates :scim_id, presence: true, uniqueness: true
-    validates :external_id, presence: true
+    validates :external_id, presence: true, uniqueness: { scope: :resource_type }
     validates :display_name, presence: true
     validates :resource_type, presence: true
     validates :scim_data, presence: true

--- a/packages/two_percent/app/models/two_percent/scim_group_membership.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group_membership.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TwoPercent
+  class ScimGroupMembership < ApplicationRecord
+    self.table_name = "two_percent_scim_group_memberships"
+
+    belongs_to :scim_user, class_name: "TwoPercent::ScimUser",
+                           foreign_key: :scim_user_id
+    belongs_to :scim_group, class_name: "TwoPercent::ScimGroup",
+                            foreign_key: :scim_group_id
+
+    validates :scim_user_id, presence: true
+    validates :scim_group_id, presence: true
+    validates :scim_user_id, uniqueness: { scope: :scim_group_id, message: "already a member of this group" }
+
+    def self.find_or_create_membership(scim_user:, scim_group:, correlation_id: nil)
+      find_or_create_by!(
+        scim_user_id: scim_user.id,
+        scim_group_id: scim_group.id
+      ) do |membership|
+        membership.correlation_id = correlation_id
+      end
+    end
+
+    def self.remove_membership(scim_user:, scim_group:)
+      find_by(scim_user_id: scim_user.id, scim_group_id: scim_group.id)&.destroy
+    end
+  end
+end

--- a/packages/two_percent/app/models/two_percent/scim_group_membership.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group_membership.rb
@@ -13,13 +13,11 @@ module TwoPercent
     validates :scim_group_id, presence: true
     validates :scim_user_id, uniqueness: { scope: :scim_group_id, message: "already a member of this group" }
 
-    def self.find_or_create_membership(scim_user:, scim_group:, correlation_id: nil)
+    def self.find_or_create_membership(scim_user:, scim_group:)
       find_or_create_by!(
         scim_user_id: scim_user.id,
         scim_group_id: scim_group.id
-      ) do |membership|
-        membership.correlation_id = correlation_id
-      end
+      )
     end
 
     def self.remove_membership(scim_user:, scim_group:)

--- a/packages/two_percent/app/models/two_percent/scim_user.rb
+++ b/packages/two_percent/app/models/two_percent/scim_user.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module TwoPercent
+  class ScimUser < ApplicationRecord
+    self.table_name = "two_percent_scim_users"
+    serialize :scim_data, coder: JSON
+
+    has_many :scim_group_memberships, class_name: "TwoPercent::ScimGroupMembership",
+                                      foreign_key: :scim_user_id, dependent: :destroy
+    has_many :scim_groups, through: :scim_group_memberships
+
+    validates :scim_id, presence: true, uniqueness: true
+    validates :external_id, presence: true
+    validates :scim_data, presence: true
+
+    scope :active, -> { where(active: true) }
+
+    # Creates or updates a user from SCIM data
+    #
+    # Generates a UUID for the id field if not present (for POST/create operations).
+    # Validates the SCIM data against the User schema before persisting.
+    #
+    # @param scim_hash [Hash] SCIM User resource hash conforming to RFC 7643
+    # @param correlation_id [String, nil] Optional correlation ID for tracking
+    #   changes across network hops (e.g., App A -> App B -> App C)
+    # @return [TwoPercent::ScimUser] The persisted user record
+    # @raise [TwoPercent::Scim::ValidationError] If SCIM data fails schema validation
+    def self.upsert_from_scim(scim_hash, correlation_id: nil)
+      # Generate ID if not present (for POST/create operations)
+      scim_hash = scim_hash.dup
+      scim_hash["id"] ||= SecureRandom.uuid
+
+      validated_data = TwoPercent::Scim::Schema.validate_user(scim_hash, require_id: true)
+      scim_user = find_or_initialize_by(scim_id: scim_hash["id"])
+      scim_user.update_from_scim!(validated_data, correlation_id: correlation_id)
+      scim_user
+    end
+
+    def self.find_by_scim_id(scim_id)
+      find_by(scim_id: scim_id)
+    end
+
+    def self.exists_by_scim_id?(scim_id)
+      exists?(scim_id: scim_id)
+    end
+
+    def self.destroy_by_scim_id(scim_id)
+      find_by_scim_id(scim_id)&.destroy
+    end
+
+    # Extracts domain attributes for publishing in domain events
+    #
+    # Returns key attributes for event payloads.
+    # Includes associated group memberships if loaded.
+    #
+    # @return [Hash] Domain attributes
+    def to_domain_attributes
+      attributes = {
+        scim_id: scim_id,
+        external_id: external_id,
+        user_name: user_name,
+        display_name: display_name,
+        email: email,
+        active: active,
+      }
+
+      attributes[:groups] = group_memberships_attributes if scim_groups.loaded? || scim_groups.any?
+      attributes.compact
+    end
+
+    # Returns full SCIM representation for HTTP responses
+    #
+    # @return [Hash] RFC 7644 compliant SCIM User resource
+    def to_scim_representation
+      scim_data.merge(
+        "id" => scim_id,
+        "meta" => {
+          "resourceType" => "User",
+          "created" => created_at.iso8601,
+          "lastModified" => updated_at.iso8601,
+        }
+      )
+    end
+
+    def update_from_scim!(validated_data, correlation_id: nil)
+      core_data = validated_data[:core]
+      self.scim_data = core_data.merge(validated_data[:extensions])
+      self.scim_id = core_data["id"]
+      self.external_id = core_data["externalId"]
+      self.user_name = core_data["userName"]
+      self.display_name = core_data["displayName"]
+      self.email = core_data.dig("emails", 0, "value")
+      self.active = core_data.fetch("active", true)
+      self.correlation_id = correlation_id
+      save!
+      sync_groups(core_data["groups"]) if core_data["groups"]
+    end
+
+    def sync_groups(groups_data)
+      return if groups_data.blank?
+
+      group_ids = groups_data.filter_map { |g| g["value"] }
+      groups = TwoPercent::ScimGroup.where(scim_id: group_ids)
+      self.scim_groups = groups
+    end
+
+    # Extracts a nested attribute from the scim_data JSON
+    #
+    # @param path [String] Dot-separated path to the attribute (e.g., "name.givenName")
+    # @return [Object, nil] The attribute value or nil if not found
+    # @example
+    #   user.scim_attribute("emails.0.value") # => "user@example.com"
+    def scim_attribute(path)
+      keys = path.split(".")
+      scim_data.dig(*keys)
+    end
+
+    def extension_attributes(schema_urn = nil)
+      if schema_urn
+        scim_data[schema_urn] || {}
+      else
+        scim_data.select { |k, _| k.start_with?("urn:ietf:params:scim:schemas:extension:") }
+      end
+    end
+
+  private
+
+    def group_memberships_attributes
+      scim_groups.map do |group|
+        {
+          scim_id: group.scim_id,
+          display_name: group.display_name,
+          resource_type: group.resource_type,
+        }
+      end
+    end
+  end
+end

--- a/packages/two_percent/app/models/two_percent/scim_user.rb
+++ b/packages/two_percent/app/models/two_percent/scim_user.rb
@@ -10,7 +10,7 @@ module TwoPercent
     has_many :scim_groups, through: :scim_group_memberships
 
     validates :scim_id, presence: true, uniqueness: true
-    validates :external_id, presence: true
+    validates :external_id, presence: true, uniqueness: true
     validates :scim_data, presence: true
 
     scope :active, -> { where(active: true) }

--- a/packages/two_percent/lib/generators/two_percent/install/install_generator.rb
+++ b/packages/two_percent/lib/generators/two_percent/install/install_generator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+require "rails/generators/migration"
+require "rails/generators/active_record"
+
+module TwoPercent
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      include Rails::Generators::Migration
+
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Installs TwoPercent SCIM integration with migrations and initializer"
+
+      def self.next_migration_number(path)
+        ActiveRecord::Generators::Base.next_migration_number(path)
+      end
+
+      def copy_migrations
+        migration_template(
+          "create_two_percent_scim_users.rb.erb",
+          "db/migrate/create_two_percent_scim_users.rb"
+        )
+
+        migration_template(
+          "create_two_percent_scim_groups.rb.erb",
+          "db/migrate/create_two_percent_scim_groups.rb"
+        )
+
+        migration_template(
+          "create_two_percent_scim_group_memberships.rb.erb",
+          "db/migrate/create_two_percent_scim_group_memberships.rb"
+        )
+      end
+
+      def copy_initializer
+        template "two_percent.rb.erb", "config/initializers/two_percent.rb"
+      end
+
+      def show_readme
+        readme "INSTALL_README" if behavior == :invoke
+      end
+    end
+  end
+end

--- a/packages/two_percent/lib/generators/two_percent/install/templates/INSTALL_README
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/INSTALL_README
@@ -1,0 +1,84 @@
+===============================================================================
+  TwoPercent SCIM Integration Installed Successfully!
+===============================================================================
+
+Next Steps:
+
+1. Run migrations to create SCIM tables:
+
+   rails db:migrate
+
+2. Configure authentication in config/initializers/two_percent.rb:
+
+   Replace the NotImplementedError with your authentication logic
+   (bearer token, BasicAuth, API key, etc.)
+
+3. Mount SCIM routes in config/routes.rb:
+
+   mount TwoPercent::Engine => "/scim"
+
+   Or mount at a custom path:
+   mount TwoPercent::Engine => "/api/scim/v2"
+
+4. Subscribe to domain events:
+
+   TwoPercent publishes domain events when SCIM resources change:
+
+   - TwoPercent::Domain::Events::UserCreated
+   - TwoPercent::Domain::Events::UserUpdated
+   - TwoPercent::Domain::Events::UserDeleted
+   - TwoPercent::Domain::Events::GroupCreated
+   - TwoPercent::Domain::Events::GroupUpdated
+   - TwoPercent::Domain::Events::GroupDeleted
+
+   Subscribe using ActiveSupport::Notifications or integrate using the
+   Syncable concern (see step 5)
+
+5. (Option A) Subscribe to events manually:
+
+   ActiveSupport::Notifications.subscribe(/TwoPercent::Domain::Events/) do |name, start, finish, id, payload|
+     event = payload[:event]
+     case event
+     when TwoPercent::Domain::Events::UserCreated
+       User.create!(scim_id: event.user_attributes[:scim_id], ...)
+     when TwoPercent::Domain::Events::UserUpdated
+       user = User.find_by(scim_id: event.user_attributes[:scim_id])
+       user&.update!(event.user_attributes.slice(...))
+     end
+   end
+
+6. (Option B) Use Syncable concern for automatic sync:
+
+   class User < ApplicationRecord
+     include TwoPercent::Syncable
+
+     syncable_as :user, scim_id_column: :scim_id do |scim_attrs|
+       {
+         first_name: scim_attrs.dig(:name, :givenName),
+         last_name: scim_attrs.dig(:name, :familyName),
+         email: scim_attrs[:email],
+         active: scim_attrs[:active]
+       }
+     end
+   end
+
+   Then subscribe to events:
+   ActiveSupport::Notifications.subscribe(/TwoPercent::Domain::Events/) do |name, start, finish, id, payload|
+     event = payload[:event]
+     User.sync_from_scim_event(event) if event.is_a?(TwoPercent::Domain::Events::Base)
+   end
+
+7. (Option C) Query SCIM models directly:
+
+   scim_user = TwoPercent::ScimUser.find_by_scim_id("user-123")
+   attrs = scim_user.to_domain_attributes
+   email = scim_user.scim_data["email"]
+
+===============================================================================
+
+For detailed documentation and examples, see:
+https://github.com/powerhome/power-tools/tree/main/packages/two_percent
+
+Questions or issues? Open an issue on GitHub.
+
+===============================================================================

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
@@ -5,14 +5,12 @@ class CreateTwoPercentScimGroupMemberships < ActiveRecord::Migration[7.0]
     create_table :two_percent_scim_group_memberships do |t|
       t.integer :scim_user_id, null: false
       t.integer :scim_group_id, null: false
-      t.string :correlation_id
 
       t.timestamps
 
       t.index :scim_user_id
       t.index :scim_group_id
       t.index [:scim_user_id, :scim_group_id], unique: true, name: "index_scim_memberships_on_user_and_group"
-      t.index :correlation_id
     end
 
     # Note: No explicit foreign keys for Percona/MySQL compatibility

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateTwoPercentScimGroupMemberships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :two_percent_scim_group_memberships do |t|
+      t.integer :scim_user_id, null: false
+      t.integer :scim_group_id, null: false
+      t.string :correlation_id
+
+      t.timestamps
+
+      t.index :scim_user_id
+      t.index :scim_group_id
+      t.index [:scim_user_id, :scim_group_id], unique: true, name: "index_scim_memberships_on_user_and_group"
+      t.index :correlation_id
+    end
+
+    # Note: No explicit foreign keys for Percona/MySQL compatibility
+  end
+end

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_groups.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_groups.rb.erb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateTwoPercentScimGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :two_percent_scim_groups do |t|
+      t.string :scim_id, null: false
+      t.string :external_id, null: false
+      t.string :display_name, null: false
+      t.string :resource_type, null: false
+      t.boolean :active, default: true
+      t.text :scim_data, limit: 16_777_215  # MEDIUMTEXT for MySQL
+      t.string :correlation_id
+
+      t.timestamps
+
+      t.index :scim_id, unique: true
+      t.index :external_id
+      t.index [:resource_type, :external_id], name: "index_scim_groups_on_resource_and_external_id"
+      t.index :resource_type
+      t.index :active
+      t.index :correlation_id
+    end
+  end
+end

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_groups.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_groups.rb.erb
@@ -14,8 +14,7 @@ class CreateTwoPercentScimGroups < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.index :scim_id, unique: true
-      t.index :external_id
-      t.index [:resource_type, :external_id], name: "index_scim_groups_on_resource_and_external_id"
+      t.index [:resource_type, :external_id], unique: true, name: "index_scim_groups_on_resource_and_external_id"
       t.index :resource_type
       t.index :active
       t.index :correlation_id

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_users.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_users.rb.erb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateTwoPercentScimUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :two_percent_scim_users do |t|
+      t.string :scim_id, null: false
+      t.string :external_id, null: false
+      t.string :user_name
+      t.string :display_name
+      t.string :email
+      t.boolean :active, default: true
+      t.text :scim_data, limit: 16_777_215  # MEDIUMTEXT for MySQL
+      t.string :correlation_id
+
+      t.timestamps
+
+      t.index :scim_id, unique: true
+      t.index :external_id
+      t.index :user_name
+      t.index :email
+      t.index :active
+      t.index :correlation_id
+    end
+  end
+end

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_users.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_users.rb.erb
@@ -15,7 +15,7 @@ class CreateTwoPercentScimUsers < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.index :scim_id, unique: true
-      t.index :external_id
+      t.index :external_id, unique: true
       t.index :user_name
       t.index :email
       t.index :active

--- a/packages/two_percent/lib/generators/two_percent/install/templates/two_percent.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/two_percent.rb.erb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  TwoPercent.configure do |config|
+    # ============================================================
+    # Authentication (Required)
+    # ============================================================
+    # Define how to authenticate SCIM requests
+    # This should return truthy value for authenticated requests
+    #
+    # Example with bearer token:
+    #   config.authenticate = ->(request) do
+    #     token = request.headers["Authorization"]&.remove("Bearer ")
+    #     token == Rails.application.credentials.scim_token
+    #   end
+    #
+    # Example with BasicAuth:
+    #   config.authenticate = ->(request) do
+    #     ActionController::HttpAuthentication::Basic.authenticate(request) do |username, password|
+    #       username == "scim_user" && password == Rails.application.credentials.scim_password
+    #     end
+    #   end
+    #
+    config.authenticate = ->(request) do
+      # TODO: Implement your authentication logic here
+      # Return true for authenticated requests, false otherwise
+      raise NotImplementedError, "TwoPercent authentication not configured"
+    end
+
+    # ============================================================
+    # Integration with Your Application
+    # ============================================================
+    # TwoPercent publishes domain events when SCIM resources change.
+    # Choose your integration approach:
+    #
+    # Option 1: Subscribe to domain events (recommended)
+    #   ActiveSupport::Notifications.subscribe(/TwoPercent::Domain::Events/) do |name, start, finish, id, payload|
+    #     event = payload[:event]
+    #     case event
+    #     when TwoPercent::Domain::Events::UserCreated
+    #       User.create!(
+    #         scim_id: event.user_attributes[:scim_id],
+    #         email: event.user_attributes[:email],
+    #         first_name: event.user_attributes.dig(:name, :givenName)
+    #       )
+    #     when TwoPercent::Domain::Events::UserUpdated
+    #       user = User.find_by(scim_id: event.user_attributes[:scim_id])
+    #       user&.update!(email: event.user_attributes[:email])
+    #     end
+    #   end
+    #
+    # Option 2: Use the Syncable concern (declarative)
+    #   class User < ApplicationRecord
+    #     include TwoPercent::Syncable
+    #
+    #     syncable_as :user, scim_id_column: :scim_id do |scim_attrs|
+    #       {
+    #         first_name: scim_attrs.dig(:name, :givenName),
+    #         last_name: scim_attrs.dig(:name, :familyName),
+    #         email: scim_attrs[:email],
+    #         active: scim_attrs[:active]
+    #       }
+    #     end
+    #   end
+    #
+    #   # Then subscribe to events and sync automatically:
+    #   ActiveSupport::Notifications.subscribe(/TwoPercent::Domain::Events/) do |name, start, finish, id, payload|
+    #     event = payload[:event]
+    #     User.sync_from_scim_event(event) if event.is_a?(TwoPercent::Domain::Events::Base)
+    #   end
+    #
+    # Option 3: Query SCIM models directly
+    #   scim_user = TwoPercent::ScimUser.find_by_scim_id("user-123")
+    #   email = scim_user.scim_data["email"]
+    #   attrs = scim_user.to_domain_attributes
+    #
+    # Events published:
+    # - TwoPercent::Domain::Events::UserCreated
+    # - TwoPercent::Domain::Events::UserUpdated
+    # - TwoPercent::Domain::Events::UserDeleted
+    # - TwoPercent::Domain::Events::GroupCreated
+    # - TwoPercent::Domain::Events::GroupUpdated
+    # - TwoPercent::Domain::Events::GroupDeleted
+  end
+end

--- a/packages/two_percent/lib/two_percent/version.rb
+++ b/packages/two_percent/lib/two_percent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TwoPercent
-  VERSION = "0.5.0"
+  VERSION = "0.6.0" # intermediate version between 0.5.0 and 1.x.x
 end

--- a/packages/two_percent/spec/models/scim_group_membership_spec.rb
+++ b/packages/two_percent/spec/models/scim_group_membership_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TwoPercent::ScimGroupMembership, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:scim_user) }
+    it { is_expected.to belong_to(:scim_group) }
+  end
+
+  describe "validations" do
+    subject(:membership) { build_membership }
+
+    it "validates presence of scim_user" do
+      membership.scim_user = nil
+      expect(membership).not_to be_valid
+      expect(membership.errors[:scim_user]).to be_present
+    end
+
+    it "validates presence of scim_group" do
+      membership.scim_group = nil
+      expect(membership).not_to be_valid
+      expect(membership.errors[:scim_group]).to be_present
+    end
+
+    context "uniqueness validation" do
+      let!(:user) { create_scim_user }
+      let!(:group) { create_scim_group }
+      let!(:existing_membership) do
+        described_class.create!(scim_user: user, scim_group: group)
+      end
+
+      it "prevents duplicate memberships for the same user and group" do
+        duplicate = described_class.new(scim_user: user, scim_group: group)
+
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:scim_user_id]).to be_present
+      end
+
+      it "allows the same user in different groups" do
+        other_group = create_scim_group
+        membership = described_class.new(scim_user: user, scim_group: other_group)
+
+        expect(membership).to be_valid
+      end
+
+      it "allows different users in the same group" do
+        other_user = create_scim_user
+        membership = described_class.new(scim_user: other_user, scim_group: group)
+
+        expect(membership).to be_valid
+      end
+    end
+  end
+
+  describe "database persistence" do
+    it "persists to database" do
+      user = create_scim_user
+      group = create_scim_group
+
+      expect do
+        described_class.create!(scim_user: user, scim_group: group)
+      end.to change { described_class.count }.by(1)
+    end
+
+    it "can be retrieved from database" do
+      user = create_scim_user
+      group = create_scim_group
+      membership = described_class.create!(scim_user: user, scim_group: group)
+
+      retrieved = described_class.find(membership.id)
+      expect(retrieved.scim_user).to eq(user)
+      expect(retrieved.scim_group).to eq(group)
+    end
+  end
+
+  describe "cascade delete behavior" do
+    let(:user) { create_scim_user }
+    let(:group) { create_scim_group }
+    let!(:membership) { described_class.create!(scim_user: user, scim_group: group) }
+
+    it "is deleted when user is destroyed" do
+      expect do
+        user.destroy
+      end.to change { described_class.count }.by(-1)
+    end
+
+    it "is deleted when group is destroyed" do
+      expect do
+        group.destroy
+      end.to change { described_class.count }.by(-1)
+    end
+  end
+
+  describe "querying memberships" do
+    let!(:user1) { create_scim_user(scim_id: "user-1") }
+    let!(:user2) { create_scim_user(scim_id: "user-2") }
+    let!(:group1) { create_scim_group(scim_id: "group-1") }
+    let!(:group2) { create_scim_group(scim_id: "group-2") }
+
+    before do
+      described_class.create!(scim_user: user1, scim_group: group1)
+      described_class.create!(scim_user: user1, scim_group: group2)
+      described_class.create!(scim_user: user2, scim_group: group1)
+    end
+
+    it "finds all memberships for a user" do
+      memberships = described_class.where(scim_user: user1)
+      expect(memberships.count).to eq(2)
+    end
+
+    it "finds all memberships for a group" do
+      memberships = described_class.where(scim_group: group1)
+      expect(memberships.count).to eq(2)
+    end
+
+    it "finds specific user-group membership" do
+      membership = described_class.find_by(scim_user: user1, scim_group: group1)
+      expect(membership).to be_present
+    end
+  end
+
+  describe "bulk operations" do
+    let(:user) { create_scim_user }
+    let(:groups) { Array.new(3) { create_scim_group } }
+
+    it "can create multiple memberships at once" do
+      expect do
+        groups.each do |group|
+          described_class.create!(scim_user: user, scim_group: group)
+        end
+      end.to change { described_class.count }.by(3)
+    end
+
+    it "can delete multiple memberships at once" do
+      groups.each do |group|
+        described_class.create!(scim_user: user, scim_group: group)
+      end
+
+      expect do
+        described_class.where(scim_user: user).destroy_all
+      end.to change { described_class.count }.by(-3)
+    end
+  end
+
+  # Test helpers
+  def build_membership(attributes = {})
+    default_attributes = {
+      scim_user: create_scim_user,
+      scim_group: create_scim_group,
+    }
+    described_class.new(default_attributes.merge(attributes))
+  end
+
+  def create_scim_user(attributes = {})
+    scim_id = attributes[:scim_id] || "user-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test User"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "userName" => "test.user@example.com",
+      "displayName" => display_name,
+      "emails" => [{ "value" => "test.user@example.com", "type" => "work", "primary" => true }],
+      "active" => true,
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      user_name: "test.user@example.com",
+      display_name: display_name,
+      email: "test.user@example.com",
+      active: true,
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    TwoPercent::ScimUser.create!(full_attributes)
+  end
+
+  def create_scim_group(attributes = {})
+    scim_id = attributes[:scim_id] || "group-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test Group"
+    resource_type = attributes[:resource_type] || "Groups"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "displayName" => display_name,
+      "members" => [],
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      display_name: display_name,
+      resource_type: resource_type,
+      active: true,
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    TwoPercent::ScimGroup.create!(full_attributes)
+  end
+end

--- a/packages/two_percent/spec/models/scim_group_spec.rb
+++ b/packages/two_percent/spec/models/scim_group_spec.rb
@@ -1,0 +1,545 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TwoPercent::ScimGroup, type: :model do
+  describe "validations" do
+    subject(:scim_group) { build_scim_group }
+
+    it { is_expected.to validate_presence_of(:scim_id) }
+    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:display_name) }
+    it { is_expected.to validate_presence_of(:resource_type) }
+    it { is_expected.to validate_presence_of(:scim_data) }
+
+    it { is_expected.to validate_uniqueness_of(:scim_id) }
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:scim_group_memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:scim_users).through(:scim_group_memberships) }
+
+    it "destroys memberships when group is destroyed" do
+      group = create_scim_group
+      user = create_scim_user
+      membership = TwoPercent::ScimGroupMembership.create!(scim_user: user, scim_group: group)
+
+      expect { group.destroy }.to change { TwoPercent::ScimGroupMembership.count }.by(-1)
+      expect(TwoPercent::ScimGroupMembership.exists?(membership.id)).to be false
+    end
+  end
+
+  describe "scopes" do
+    describe ".active" do
+      it "returns only active groups" do
+        active_group = create_scim_group(active: true)
+        inactive_group = create_scim_group(active: false)
+
+        expect(described_class.active).to include(active_group)
+        expect(described_class.active).not_to include(inactive_group)
+      end
+    end
+
+    describe ".by_resource_type" do
+      it "returns groups filtered by resource type" do
+        departments = create_scim_group(resource_type: "Departments")
+        roles = create_scim_group(resource_type: "Roles")
+        titles = create_scim_group(resource_type: "Titles")
+
+        expect(described_class.by_resource_type("Departments")).to include(departments)
+        expect(described_class.by_resource_type("Departments")).not_to include(roles, titles)
+      end
+    end
+  end
+
+  describe ".upsert_from_scim" do
+    let(:resource_type) { "Departments" }
+    let(:scim_hash) do
+      {
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "id" => "group-123",
+        "externalId" => "ext-123",
+        "displayName" => "Engineering",
+        "members" => [],
+      }
+    end
+
+    context "when group does not exist" do
+      it "creates a new group" do
+        expect do
+          described_class.upsert_from_scim(resource_type, scim_hash)
+        end.to change { described_class.count }.by(1)
+      end
+
+      it "sets all attributes correctly" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.scim_id).to eq("group-123")
+        expect(group.external_id).to eq("ext-123")
+        expect(group.display_name).to eq("Engineering")
+        expect(group.resource_type).to eq("Departments")
+        expect(group.active).to be true
+      end
+
+      it "stores full SCIM data in scim_data column" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.scim_data).to be_a(Hash)
+        expect(group.scim_data["id"]).to eq("group-123")
+        expect(group.scim_data["displayName"]).to eq("Engineering")
+      end
+
+      it "persists to database" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group).to be_persisted
+        expect(group.id).not_to be_nil
+      end
+    end
+
+    context "when group already exists" do
+      let!(:existing_group) { create_scim_group(scim_id: "group-123", display_name: "Old Name") }
+
+      it "does not create a new group" do
+        expect do
+          described_class.upsert_from_scim(resource_type, scim_hash)
+        end.not_to(change { described_class.count })
+      end
+
+      it "updates existing group attributes" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.id).to eq(existing_group.id)
+        expect(group.display_name).to eq("Engineering")
+        expect(group.display_name).not_to eq("Old Name")
+      end
+
+      it "updates scim_data" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.scim_data["displayName"]).to eq("Engineering")
+      end
+    end
+
+    context "with members array" do
+      let!(:user1) { create_scim_user(scim_id: "user-1") }
+      let!(:user2) { create_scim_user(scim_id: "user-2") }
+
+      let(:scim_hash_with_members) do
+        scim_hash.merge(
+          "members" => [
+            { "value" => "user-1", "display" => "User One" },
+            { "value" => "user-2", "display" => "User Two" },
+          ]
+        )
+      end
+
+      it "syncs members when present" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash_with_members)
+
+        expect(group.scim_users.count).to eq(2)
+        expect(group.scim_users).to include(user1, user2)
+      end
+
+      it "does not sync members when array is empty" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.scim_users.count).to eq(0)
+      end
+    end
+
+    context "with correlation_id" do
+      it "stores the correlation_id when provided" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash, correlation_id: "abc-123")
+
+        expect(group.correlation_id).to eq("abc-123")
+      end
+
+      it "allows nil correlation_id" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash, correlation_id: nil)
+
+        expect(group.correlation_id).to be_nil
+      end
+    end
+
+    context "with extension schemas containing active flag" do
+      let(:scim_hash_with_active_false) do
+        scim_hash.merge(
+          "urn:ietf:params:scim:schemas:extension:authservice:2.0:Group" => {
+            "active" => false,
+          }
+        )
+      end
+
+      it "sets active to false when extension has active: false" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash_with_active_false)
+
+        expect(group.active).to be false
+      end
+
+      it "defaults active to true when extension missing" do
+        group = described_class.upsert_from_scim(resource_type, scim_hash)
+
+        expect(group.active).to be true
+      end
+    end
+
+    context "with different resource types" do
+      it "handles Departments" do
+        group = described_class.upsert_from_scim("Departments", scim_hash)
+        expect(group.resource_type).to eq("Departments")
+      end
+
+      it "handles Roles" do
+        group = described_class.upsert_from_scim("Roles", scim_hash)
+        expect(group.resource_type).to eq("Roles")
+      end
+
+      it "handles Titles" do
+        group = described_class.upsert_from_scim("Titles", scim_hash)
+        expect(group.resource_type).to eq("Titles")
+      end
+
+      it "handles Territories" do
+        group = described_class.upsert_from_scim("Territories", scim_hash)
+        expect(group.resource_type).to eq("Territories")
+      end
+
+      it "handles Groups" do
+        group = described_class.upsert_from_scim("Groups", scim_hash)
+        expect(group.resource_type).to eq("Groups")
+      end
+    end
+
+    context "with invalid SCIM data" do
+      it "validates SCIM schema before persisting" do
+        invalid_hash = { "id" => "group-123" } # Missing required fields
+
+        expect do
+          described_class.upsert_from_scim(resource_type, invalid_hash)
+        end.to raise_error(ArgumentError, /schemas attribute is required/)
+      end
+    end
+  end
+
+  describe ".find_by_scim_id" do
+    it "finds group by scim_id" do
+      group = create_scim_group(scim_id: "group-456")
+
+      found_group = described_class.find_by_scim_id("group-456")
+      expect(found_group).to eq(group)
+    end
+
+    it "returns nil when group not found" do
+      expect(described_class.find_by_scim_id("nonexistent")).to be_nil
+    end
+  end
+
+  describe ".exists_by_scim_id?" do
+    it "returns true when group exists" do
+      create_scim_group(scim_id: "group-789")
+
+      expect(described_class.exists_by_scim_id?("group-789")).to be true
+    end
+
+    it "returns false when group does not exist" do
+      expect(described_class.exists_by_scim_id?("nonexistent")).to be false
+    end
+  end
+
+  describe ".destroy_by_scim_id" do
+    context "when group exists" do
+      let!(:group) { create_scim_group(scim_id: "group-999") }
+
+      it "destroys the group" do
+        expect do
+          described_class.destroy_by_scim_id("group-999")
+        end.to change { described_class.count }.by(-1)
+      end
+
+      it "returns the destroyed group" do
+        result = described_class.destroy_by_scim_id("group-999")
+        expect(result).to be_a(described_class)
+        expect(result.scim_id).to eq("group-999")
+        expect(result).to be_destroyed
+      end
+    end
+
+    context "when group does not exist" do
+      it "returns nil" do
+        result = described_class.destroy_by_scim_id("nonexistent")
+        expect(result).to be_nil
+      end
+
+      it "does not raise an error" do
+        expect do
+          described_class.destroy_by_scim_id("nonexistent")
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe "#replace_members" do
+    let(:group) { create_scim_group }
+    let!(:user1) { create_scim_user(scim_id: "user-1") }
+    let!(:user2) { create_scim_user(scim_id: "user-2") }
+    let!(:user3) { create_scim_user(scim_id: "user-3") }
+
+    context "when adding new members" do
+      let(:members_array) do
+        [
+          { "value" => "user-1" },
+          { "value" => "user-2" },
+        ]
+      end
+
+      it "creates memberships for new members" do
+        expect do
+          group.replace_members(members_array, "corr-123")
+        end.to change { group.scim_group_memberships.count }.by(2)
+
+        expect(group.scim_users).to include(user1, user2)
+      end
+
+    end
+
+    context "when removing members" do
+      before do
+        TwoPercent::ScimGroupMembership.create!(scim_user: user1, scim_group: group)
+        TwoPercent::ScimGroupMembership.create!(scim_user: user2, scim_group: group)
+        TwoPercent::ScimGroupMembership.create!(scim_user: user3, scim_group: group)
+      end
+
+      let(:members_array) do
+        [{ "value" => "user-1" }] # Only keep user1
+      end
+
+      it "removes memberships not in the array" do
+        expect do
+          group.replace_members(members_array, "corr-456")
+        end.to change { group.scim_group_memberships.count }.by(-2)
+
+        group.reload
+        expect(group.scim_users).to eq([user1])
+        expect(group.scim_users).not_to include(user2, user3)
+      end
+    end
+
+    context "when members already exist" do
+      before do
+        TwoPercent::ScimGroupMembership.create!(scim_user: user1, scim_group: group)
+      end
+
+      let(:members_array) do
+        [
+          { "value" => "user-1" },
+          { "value" => "user-2" },
+        ]
+      end
+
+      it "does not duplicate existing memberships" do
+        # Only adds user2
+        expect do
+          group.replace_members(members_array, "corr-789")
+        end.to change { group.scim_group_memberships.count }.by(1)
+        expect(group.scim_users).to include(user1, user2)
+      end
+    end
+
+    context "with empty members array" do
+      before do
+        TwoPercent::ScimGroupMembership.create!(scim_user: user1, scim_group: group)
+        TwoPercent::ScimGroupMembership.create!(scim_user: user2, scim_group: group)
+      end
+
+      it "removes all memberships" do
+        expect do
+          group.replace_members([], "corr-empty")
+        end.to change { group.scim_group_memberships.count }.from(2).to(0)
+      end
+    end
+
+    context "when member scim_ids do not exist" do
+      let(:members_array) do
+        [{ "value" => "nonexistent-user" }]
+      end
+
+      it "raises error for non-existent users" do
+        expect do
+          group.replace_members(members_array, "corr-404")
+        end.to raise_error(ArgumentError, /Cannot add non-existent users to group: nonexistent-user/)
+      end
+    end
+  end
+
+  describe "#to_domain_attributes" do
+    let(:group) { create_scim_group(resource_type: "Departments") }
+
+    it "returns a hash with domain attributes" do
+      attributes = group.to_domain_attributes
+
+      expect(attributes).to be_a(Hash)
+      expect(attributes).to include(
+        :scim_id,
+        :external_id,
+        :display_name,
+        :active,
+        :resource_type
+      )
+    end
+
+    it "includes resource_type" do
+      attributes = group.to_domain_attributes
+
+      expect(attributes[:resource_type]).to eq("Departments")
+    end
+  end
+
+  describe "#to_scim_representation" do
+    let(:group) { create_scim_group(resource_type: "Departments") }
+
+    it "returns RFC 7644 compliant SCIM Group resource" do
+      scim_repr = group.to_scim_representation
+
+      expect(scim_repr).to be_a(Hash)
+      expect(scim_repr["schemas"]).to include("urn:ietf:params:scim:schemas:core:2.0:Group")
+      expect(scim_repr["id"]).to eq(group.scim_id)
+    end
+
+    it "includes meta information" do
+      scim_repr = group.to_scim_representation
+
+      expect(scim_repr["meta"]).to be_present
+      expect(scim_repr["meta"]["resourceType"]).to eq("Departments")
+    end
+
+    it "includes core attributes" do
+      scim_repr = group.to_scim_representation
+
+      expect(scim_repr).to include("displayName")
+    end
+
+    it "includes members array" do
+      user1 = create_scim_user(scim_id: "user-1", display_name: "User One")
+      user2 = create_scim_user(scim_id: "user-2", display_name: "User Two")
+      TwoPercent::ScimGroupMembership.create!(scim_user: user1, scim_group: group)
+      TwoPercent::ScimGroupMembership.create!(scim_user: user2, scim_group: group)
+
+      # Eager-load members to test serialization
+      group_with_members = TwoPercent::ScimGroup.includes(:scim_users).find(group.id)
+      scim_repr = group_with_members.to_scim_representation
+
+      expect(scim_repr["members"]).to be_an(Array)
+      expect(scim_repr["members"].size).to eq(2)
+    end
+  end
+
+  describe "#scim_attribute" do
+    let(:scim_data) do
+      {
+        "displayName" => "Engineering",
+        "meta" => {
+          "resourceType" => "Departments",
+        },
+        "members" => [
+          { "value" => "user-1", "display" => "User One" },
+        ],
+      }
+    end
+    let(:group) { create_scim_group(scim_data: scim_data) }
+
+    it "returns attribute by dot-notation path" do
+      expect(group.scim_attribute("displayName")).to eq("Engineering")
+    end
+
+    it "handles nested paths" do
+      expect(group.scim_attribute("meta.resourceType")).to eq("Departments")
+    end
+
+    it "returns nil for missing paths" do
+      expect(group.scim_attribute("nonexistent.path")).to be_nil
+    end
+
+    it "handles array paths" do
+      expect(group.scim_attribute("members")).to be_an(Array)
+    end
+  end
+
+  # Test helpers
+  def build_scim_group(attributes = {})
+    scim_id = attributes[:scim_id] || "group-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test Group"
+    resource_type = attributes[:resource_type] || "Groups"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "displayName" => display_name,
+      "members" => [],
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      display_name: display_name,
+      resource_type: resource_type,
+      active: attributes.fetch(:active, true),
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    described_class.new(full_attributes)
+  end
+
+  def create_scim_group(attributes = {})
+    scim_id = attributes[:scim_id] || "group-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test Group"
+    resource_type = attributes[:resource_type] || "Groups"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "displayName" => display_name,
+      "members" => [],
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      display_name: display_name,
+      resource_type: resource_type,
+      active: attributes.fetch(:active, true),
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    TwoPercent::ScimGroup.create!(full_attributes)
+  end
+
+  def create_scim_user(attributes = {})
+    scim_id = attributes[:scim_id] || "user-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test User"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "userName" => "test.user",
+      "displayName" => display_name,
+      "emails" => [{ "value" => "test@example.com", "type" => "work", "primary" => true }],
+      "active" => true,
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      user_name: "test.user",
+      display_name: display_name,
+      email: "test@example.com",
+      active: true,
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    TwoPercent::ScimUser.create!(full_attributes)
+  end
+end

--- a/packages/two_percent/spec/models/scim_user_spec.rb
+++ b/packages/two_percent/spec/models/scim_user_spec.rb
@@ -1,0 +1,454 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TwoPercent::ScimUser, type: :model do
+  describe "validations" do
+    subject(:scim_user) { build_scim_user }
+
+    it { is_expected.to validate_presence_of(:scim_id) }
+    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:scim_data) }
+
+    it { is_expected.to validate_uniqueness_of(:scim_id) }
+
+    describe "scim_id data type" do
+      it "stores scim_id as string, not integer" do
+        user = create_scim_user(scim_id: "12345")
+        expect(user.reload.scim_id).to be_a(String)
+        expect(user.scim_id).to eq("12345")
+      end
+
+      it "handles numeric-looking scim_ids correctly" do
+        user = create_scim_user(scim_id: "999999")
+        expect(user.reload.scim_id).to eq("999999")
+        expect(user.scim_id).not_to eq(999_999)
+      end
+    end
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:scim_group_memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:scim_groups).through(:scim_group_memberships) }
+
+    it "destroys memberships when user is destroyed" do
+      user = create_scim_user
+      group = create_scim_group
+      membership = TwoPercent::ScimGroupMembership.create!(scim_user: user, scim_group: group)
+
+      expect { user.destroy }.to change { TwoPercent::ScimGroupMembership.count }.by(-1)
+      expect(TwoPercent::ScimGroupMembership.exists?(membership.id)).to be false
+    end
+  end
+
+  describe "scopes" do
+    describe ".active" do
+      it "returns only active users" do
+        active_user = create_scim_user(active: true)
+        inactive_user = create_scim_user(active: false)
+
+        expect(described_class.active).to include(active_user)
+        expect(described_class.active).not_to include(inactive_user)
+      end
+    end
+  end
+
+  describe ".upsert_from_scim" do
+    let(:scim_hash) do
+      {
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id" => "user-123",
+        "externalId" => "ext-123",
+        "userName" => "john.doe",
+        "displayName" => "John Doe",
+        "emails" => [
+          { "value" => "john@example.com", "type" => "work", "primary" => true },
+        ],
+        "active" => true,
+      }
+    end
+
+    context "when user does not exist" do
+      it "creates a new user" do
+        expect do
+          described_class.upsert_from_scim(scim_hash)
+        end.to change { described_class.count }.by(1)
+      end
+
+      it "sets all attributes correctly" do
+        user = described_class.upsert_from_scim(scim_hash)
+
+        expect(user.scim_id).to eq("user-123")
+        expect(user.external_id).to eq("ext-123")
+        expect(user.user_name).to eq("john.doe")
+        expect(user.display_name).to eq("John Doe")
+        expect(user.email).to eq("john@example.com")
+        expect(user.active).to be true
+      end
+
+      it "stores full SCIM data in scim_data column" do
+        user = described_class.upsert_from_scim(scim_hash)
+
+        expect(user.scim_data).to be_a(Hash)
+        expect(user.scim_data["id"]).to eq("user-123")
+        expect(user.scim_data["userName"]).to eq("john.doe")
+      end
+
+      it "persists to database" do
+        user = described_class.upsert_from_scim(scim_hash)
+
+        expect(user).to be_persisted
+        expect(user.id).not_to be_nil
+      end
+    end
+
+    context "when user already exists" do
+      let!(:existing_user) { create_scim_user(scim_id: "user-123", display_name: "Old Name") }
+
+      it "does not create a new user" do
+        expect do
+          described_class.upsert_from_scim(scim_hash)
+        end.not_to(change { described_class.count })
+      end
+
+      it "updates existing user attributes" do
+        user = described_class.upsert_from_scim(scim_hash)
+
+        expect(user.id).to eq(existing_user.id)
+        expect(user.display_name).to eq("John Doe")
+        expect(user.display_name).not_to eq("Old Name")
+      end
+
+      it "updates scim_data" do
+        user = described_class.upsert_from_scim(scim_hash)
+
+        expect(user.scim_data["displayName"]).to eq("John Doe")
+      end
+    end
+
+    context "with correlation_id" do
+      it "stores the correlation_id when provided" do
+        user = described_class.upsert_from_scim(scim_hash, correlation_id: "abc-123")
+
+        expect(user.correlation_id).to eq("abc-123")
+      end
+
+      it "allows nil correlation_id" do
+        user = described_class.upsert_from_scim(scim_hash, correlation_id: nil)
+
+        expect(user.correlation_id).to be_nil
+      end
+    end
+
+    context "with extension schemas" do
+      let(:scim_hash_with_extension) do
+        scim_hash.merge(
+          "urn:ietf:params:scim:schemas:extension:authservice:2.0:User" => {
+            "customAttribute" => "customValue",
+          }
+        )
+      end
+
+      it "stores extension data in scim_data" do
+        user = described_class.upsert_from_scim(scim_hash_with_extension)
+
+        extension_data = user.scim_data["urn:ietf:params:scim:schemas:extension:authservice:2.0:User"]
+        expect(extension_data).to be_present
+        expect(extension_data["customAttribute"]).to eq("customValue")
+      end
+    end
+
+    context "with invalid SCIM data" do
+      it "validates SCIM schema before persisting" do
+        invalid_hash = { "id" => "user-123" } # Missing required fields
+
+        expect do
+          described_class.upsert_from_scim(invalid_hash)
+        end.to raise_error(ArgumentError, /schemas attribute is required/)
+      end
+    end
+  end
+
+  describe ".find_by_scim_id" do
+    it "finds user by scim_id" do
+      user = create_scim_user(scim_id: "user-456")
+
+      found_user = described_class.find_by_scim_id("user-456")
+      expect(found_user).to eq(user)
+    end
+
+    it "returns nil when user not found" do
+      expect(described_class.find_by_scim_id("nonexistent")).to be_nil
+    end
+  end
+
+  describe ".exists_by_scim_id?" do
+    it "returns true when user exists" do
+      create_scim_user(scim_id: "user-789")
+
+      expect(described_class.exists_by_scim_id?("user-789")).to be true
+    end
+
+    it "returns false when user does not exist" do
+      expect(described_class.exists_by_scim_id?("nonexistent")).to be false
+    end
+  end
+
+  describe ".destroy_by_scim_id" do
+    context "when user exists" do
+      let!(:user) { create_scim_user(scim_id: "user-999") }
+
+      it "destroys the user" do
+        expect do
+          described_class.destroy_by_scim_id("user-999")
+        end.to change { described_class.count }.by(-1)
+      end
+
+      it "returns the destroyed user" do
+        result = described_class.destroy_by_scim_id("user-999")
+        expect(result).to be_a(described_class)
+        expect(result.scim_id).to eq("user-999")
+        expect(result).to be_destroyed
+      end
+    end
+
+    context "when user does not exist" do
+      it "returns nil" do
+        result = described_class.destroy_by_scim_id("nonexistent")
+        expect(result).to be_nil
+      end
+
+      it "does not raise an error" do
+        expect do
+          described_class.destroy_by_scim_id("nonexistent")
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe "#to_domain_attributes" do
+    let(:user) { create_scim_user_with_groups }
+
+    it "returns a hash with domain attributes" do
+      attributes = user.to_domain_attributes
+
+      expect(attributes).to be_a(Hash)
+      expect(attributes).to include(
+        :scim_id,
+        :external_id,
+        :display_name,
+        :email,
+        :active
+      )
+    end
+
+    it "includes group memberships" do
+      attributes = user.to_domain_attributes
+
+      expect(attributes[:groups]).to be_an(Array)
+      expect(attributes[:groups].first).to include(:scim_id, :display_name, :resource_type)
+    end
+  end
+
+  describe "#to_scim_representation" do
+    let(:user) { create_scim_user }
+
+    it "returns RFC 7644 compliant SCIM User resource" do
+      scim_repr = user.to_scim_representation
+
+      expect(scim_repr).to be_a(Hash)
+      expect(scim_repr["schemas"]).to include("urn:ietf:params:scim:schemas:core:2.0:User")
+      expect(scim_repr["id"]).to eq(user.scim_id)
+    end
+
+    it "includes meta information" do
+      scim_repr = user.to_scim_representation
+
+      expect(scim_repr["meta"]).to be_present
+      expect(scim_repr["meta"]["resourceType"]).to eq("User")
+    end
+
+    it "includes core attributes" do
+      scim_repr = user.to_scim_representation
+
+      expect(scim_repr).to include("userName", "displayName", "emails", "active")
+    end
+
+    it "includes extension attributes when present" do
+      user_with_extension = create_scim_user_with_extension
+      scim_repr = user_with_extension.to_scim_representation
+
+      expect(scim_repr.keys).to include(match(/^urn:ietf:params:scim:schemas:extension:/))
+    end
+  end
+
+  describe "#scim_attribute" do
+    let(:scim_data) do
+      {
+        "userName" => "john.doe",
+        "name" => {
+          "givenName" => "John",
+          "familyName" => "Doe",
+        },
+        "emails" => [
+          { "value" => "john@example.com", "type" => "work" },
+        ],
+      }
+    end
+    let(:user) { create_scim_user(scim_data: scim_data) }
+
+    it "returns attribute by dot-notation path" do
+      expect(user.scim_attribute("userName")).to eq("john.doe")
+    end
+
+    it "handles nested paths" do
+      expect(user.scim_attribute("name.givenName")).to eq("John")
+      expect(user.scim_attribute("name.familyName")).to eq("Doe")
+    end
+
+    it "returns nil for missing paths" do
+      expect(user.scim_attribute("nonexistent.path")).to be_nil
+    end
+
+    it "handles array paths" do
+      expect(user.scim_attribute("emails")).to be_an(Array)
+    end
+  end
+
+  describe "#extension_attributes" do
+    let(:scim_data) do
+      {
+        "userName" => "john.doe",
+        "urn:ietf:params:scim:schemas:extension:authservice:2.0:User" => {
+          "department" => "Engineering",
+        },
+        "urn:ietf:params:scim:schemas:extension:custom:1.0:User" => {
+          "badge" => "12345",
+        },
+      }
+    end
+    let(:user) { create_scim_user(scim_data: scim_data) }
+
+    context "without schema URN" do
+      it "returns all extension schemas" do
+        extensions = user.extension_attributes
+
+        expect(extensions).to be_a(Hash)
+        expect(extensions.keys).to all(start_with("urn:ietf:params:scim:schemas:extension:"))
+        expect(extensions.size).to eq(2)
+      end
+
+      it "does not include core attributes" do
+        extensions = user.extension_attributes
+
+        expect(extensions).not_to have_key("userName")
+      end
+    end
+
+    context "with specific schema URN" do
+      it "returns only that extension schema" do
+        extension = user.extension_attributes("urn:ietf:params:scim:schemas:extension:authservice:2.0:User")
+
+        expect(extension).to eq({ "department" => "Engineering" })
+      end
+
+      it "returns empty hash when extension not present" do
+        extension = user.extension_attributes("urn:ietf:params:scim:schemas:extension:nonexistent:1.0:User")
+
+        expect(extension).to eq({})
+      end
+    end
+
+    context "when no extensions present" do
+      let(:user_without_extensions) { create_scim_user }
+
+      it "returns empty hash" do
+        extensions = user_without_extensions.extension_attributes
+
+        expect(extensions).to eq({})
+      end
+    end
+  end
+
+  # Test helpers
+  def build_scim_user(attributes = {})
+    default_attributes = {
+      scim_id: "user-#{SecureRandom.hex(4)}",
+      external_id: "ext-#{SecureRandom.hex(4)}",
+      user_name: "test.user",
+      display_name: "Test User",
+      email: "test@example.com",
+      active: true,
+      scim_data: {
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id" => "test",
+        "userName" => "test.user",
+        "displayName" => "Test User",
+        "emails" => [{ "value" => "test@example.com", "type" => "work", "primary" => true }],
+        "active" => true,
+      },
+    }
+    described_class.new(default_attributes.merge(attributes))
+  end
+
+  def create_scim_user(attributes = {})
+    build_scim_user(attributes).tap(&:save!)
+  end
+
+  def create_scim_group(attributes = {})
+    scim_id = attributes[:scim_id] || "group-#{SecureRandom.hex(4)}"
+    external_id = attributes[:external_id] || "ext-#{SecureRandom.hex(4)}"
+    display_name = attributes[:display_name] || "Test Group"
+    resource_type = attributes[:resource_type] || "Groups"
+
+    default_scim_data = {
+      "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+      "id" => scim_id,
+      "externalId" => external_id,
+      "displayName" => display_name,
+      "members" => [],
+    }
+
+    full_attributes = {
+      scim_id: scim_id,
+      external_id: external_id,
+      display_name: display_name,
+      resource_type: resource_type,
+      scim_data: attributes[:scim_data] || default_scim_data,
+    }
+    TwoPercent::ScimGroup.create!(full_attributes)
+  end
+
+  def create_scim_user_with_groups
+    user = create_scim_user
+    group1 = create_scim_group(display_name: "Developers", resource_type: "Departments")
+    group2 = create_scim_group(display_name: "Managers", resource_type: "Roles")
+
+    TwoPercent::ScimGroupMembership.create!(scim_user: user, scim_group: group1)
+    TwoPercent::ScimGroupMembership.create!(scim_user: user, scim_group: group2)
+
+    user.reload
+  end
+
+  def create_scim_user_with_extension
+    scim_data_with_ext = {
+      "schemas" => [
+        "urn:ietf:params:scim:schemas:core:2.0:User",
+        "urn:ietf:params:scim:schemas:extension:authservice:2.0:User",
+      ],
+      "id" => "user-ext",
+      "userName" => "john",
+      "displayName" => "John Ext",
+      "emails" => [{ "value" => "john@example.com", "primary" => true }],
+      "urn:ietf:params:scim:schemas:extension:authservice:2.0:User" => {
+        "customField" => "customValue",
+      },
+    }
+    create_scim_user(
+      user_name: "john",
+      display_name: "John Ext",
+      email: "john@example.com",
+      scim_data: scim_data_with_ext
+    )
+  end
+end


### PR DESCRIPTION
This PR is intended as an intermediary step so we can run a migration to upgrade from v0.5.x to v1.x.x in Connect Server. This allows us to verify the data before moving to the next step updating Audiences and TwoPercent in Connect Server.

The ticket for this PR is [here](https://runway.powerhrg.com/backlog_items/SHD-1923?from=active_sprint).