### PR TITLE
[SHD-1926] Remove unneeded correlation_id on ScimGroupMembership

### DIFF
--- a/packages/two_percent/Gemfile.lock
+++ b/packages/two_percent/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    two_percent (1.1.0)
+    two_percent (1.2.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -38,7 +38,7 @@ module TwoPercent
       scim_group = find_or_initialize_by(scim_id: scim_hash["id"])
       scim_group.update_from_scim!(resource_type, validated_data, correlation_id: correlation_id)
 
-      scim_group.replace_members(scim_hash["members"], correlation_id) if scim_hash.key?("members")
+      scim_group.replace_members(scim_hash["members"]) if scim_hash.key?("members")
 
       scim_group
     end
@@ -101,7 +101,7 @@ module TwoPercent
       save!
     end
 
-    def replace_members(members_array, correlation_id)
+    def replace_members(members_array)
       member_scim_ids = members_array.filter_map { |m| m["value"] }
       existing_users = validate_users_exist!(member_scim_ids)
       existing_user_ids = scim_group_memberships.pluck(:scim_user_id)

--- a/packages/two_percent/app/models/two_percent/scim_group.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group.rb
@@ -107,7 +107,7 @@ module TwoPercent
       existing_user_ids = scim_group_memberships.pluck(:scim_user_id)
 
       users_to_add = existing_users.where.not(id: existing_user_ids)
-      bulk_insert_memberships(users_to_add, correlation_id) if users_to_add.any?
+      bulk_insert_memberships(users_to_add) if users_to_add.any?
 
       # Bulk delete removed memberships
       users_to_remove_ids = scim_users.where.not(scim_id: member_scim_ids).pluck(:id)
@@ -147,13 +147,11 @@ module TwoPercent
     # Bulk insert memberships for performance
     #
     # @param users_to_add [ActiveRecord::Relation] Users to add as members
-    # @param correlation_id [String, nil] Correlation ID for tracking
-    def bulk_insert_memberships(users_to_add, correlation_id)
+    def bulk_insert_memberships(users_to_add)
       membership_records = users_to_add.pluck(:id).map do |user_id|
         {
           scim_user_id: user_id,
           scim_group_id: id,
-          correlation_id: correlation_id,
           created_at: Time.current,
           updated_at: Time.current,
         }

--- a/packages/two_percent/app/models/two_percent/scim_group_membership.rb
+++ b/packages/two_percent/app/models/two_percent/scim_group_membership.rb
@@ -13,13 +13,11 @@ module TwoPercent
     validates :scim_group_id, presence: true
     validates :scim_user_id, uniqueness: { scope: :scim_group_id, message: "already a member of this group" }
 
-    def self.find_or_create_membership(scim_user:, scim_group:, correlation_id: nil)
+    def self.find_or_create_membership(scim_user:, scim_group:)
       find_or_create_by!(
         scim_user_id: scim_user.id,
         scim_group_id: scim_group.id
-      ) do |membership|
-        membership.correlation_id = correlation_id
-      end
+      )
     end
 
     def self.remove_membership(scim_user:, scim_group:)

--- a/packages/two_percent/docs/CHANGELOG.md
+++ b/packages/two_percent/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-17
+
+- **Simplify ScimGroupMembership**: Removed correlation_id from join table (tracking remains on ScimGroup and ScimUser)
+
 ## [1.1.0] - 2026-06-05
 
 - **GET Endpoints**: Read operations with RFC 7644 ListResponse format [#436](https://github.com/powerhome/power-tools/pull/436)

--- a/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    two_percent (1.1.0)
+    two_percent (1.2.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/two_percent/gemfiles/rails_7_2.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    two_percent (1.1.0)
+    two_percent (1.2.0)
       aether_observatory (>= 1.0)
       rails (>= 6.1)
 

--- a/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
+++ b/packages/two_percent/lib/generators/two_percent/install/templates/create_two_percent_scim_group_memberships.rb.erb
@@ -5,14 +5,12 @@ class CreateTwoPercentScimGroupMemberships < ActiveRecord::Migration[7.0]
     create_table :two_percent_scim_group_memberships do |t|
       t.integer :scim_user_id, null: false
       t.integer :scim_group_id, null: false
-      t.string :correlation_id
 
       t.timestamps
 
       t.index :scim_user_id
       t.index :scim_group_id
       t.index [:scim_user_id, :scim_group_id], unique: true, name: "index_scim_memberships_on_user_and_group"
-      t.index :correlation_id
     end
 
     # Note: No explicit foreign keys for Percona/MySQL compatibility

--- a/packages/two_percent/lib/two_percent/version.rb
+++ b/packages/two_percent/lib/two_percent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TwoPercent
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/packages/two_percent/spec/dummy/db/migrate/20260428000003_create_two_percent_scim_group_memberships.rb
+++ b/packages/two_percent/spec/dummy/db/migrate/20260428000003_create_two_percent_scim_group_memberships.rb
@@ -5,14 +5,12 @@ class CreateTwoPercentScimGroupMemberships < ActiveRecord::Migration[7.0]
     create_table :two_percent_scim_group_memberships do |t|
       t.integer :scim_user_id, null: false
       t.integer :scim_group_id, null: false
-      t.string :correlation_id
 
       t.timestamps
 
       t.index :scim_user_id
       t.index :scim_group_id
       t.index %i[scim_user_id scim_group_id], unique: true, name: "index_scim_memberships_on_user_and_group"
-      t.index :correlation_id
     end
   end
 end

--- a/packages/two_percent/spec/dummy/db/schema.rb
+++ b/packages/two_percent/spec/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,16 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_260_428_000_003) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_000003) do
   create_table "two_percent_scim_group_memberships", force: :cascade do |t|
-    t.string "correlation_id"
     t.datetime "created_at", null: false
     t.integer "scim_group_id", null: false
     t.integer "scim_user_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["correlation_id"], name: "index_two_percent_scim_group_memberships_on_correlation_id"
     t.index ["scim_group_id"], name: "index_two_percent_scim_group_memberships_on_scim_group_id"
-    t.index %w[scim_user_id scim_group_id], name: "index_scim_memberships_on_user_and_group", unique: true
+    t.index ["scim_user_id", "scim_group_id"], name: "index_scim_memberships_on_user_and_group", unique: true
     t.index ["scim_user_id"], name: "index_two_percent_scim_group_memberships_on_scim_user_id"
   end
 
@@ -32,13 +28,13 @@ ActiveRecord::Schema[7.1].define(version: 20_260_428_000_003) do
     t.string "display_name", null: false
     t.string "external_id", null: false
     t.string "resource_type", null: false
-    t.text "scim_data", limit: 16_777_215
+    t.text "scim_data", limit: 16777215
     t.string "scim_id", null: false
     t.datetime "updated_at", null: false
     t.index ["active"], name: "index_two_percent_scim_groups_on_active"
     t.index ["correlation_id"], name: "index_two_percent_scim_groups_on_correlation_id"
     t.index ["external_id"], name: "index_two_percent_scim_groups_on_external_id"
-    t.index %w[resource_type external_id], name: "index_scim_groups_on_resource_and_external_id"
+    t.index ["resource_type", "external_id"], name: "index_scim_groups_on_resource_and_external_id"
     t.index ["resource_type"], name: "index_two_percent_scim_groups_on_resource_type"
     t.index ["scim_id"], name: "index_two_percent_scim_groups_on_scim_id", unique: true
   end
@@ -50,7 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 20_260_428_000_003) do
     t.string "display_name"
     t.string "email"
     t.string "external_id", null: false
-    t.text "scim_data", limit: 16_777_215
+    t.text "scim_data", limit: 16777215
     t.string "scim_id", null: false
     t.datetime "updated_at", null: false
     t.string "user_name"

--- a/packages/two_percent/spec/dummy/db/schema.rb
+++ b/packages/two_percent/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_28_000003) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_28_000003) do
   create_table "two_percent_scim_group_memberships", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "scim_group_id", null: false

--- a/packages/two_percent/spec/models/scim_group_membership_spec.rb
+++ b/packages/two_percent/spec/models/scim_group_membership_spec.rb
@@ -53,34 +53,6 @@ RSpec.describe TwoPercent::ScimGroupMembership, type: :model do
     end
   end
 
-  describe "#correlation_id" do
-    it "stores correlation_id when provided" do
-      user = create_scim_user
-      group = create_scim_group
-
-      membership = described_class.create!(
-        scim_user: user,
-        scim_group: group,
-        correlation_id: "test-correlation-123"
-      )
-
-      expect(membership.correlation_id).to eq("test-correlation-123")
-    end
-
-    it "allows nil correlation_id" do
-      user = create_scim_user
-      group = create_scim_group
-
-      membership = described_class.create!(
-        scim_user: user,
-        scim_group: group,
-        correlation_id: nil
-      )
-
-      expect(membership.correlation_id).to be_nil
-    end
-  end
-
   describe "database persistence" do
     it "persists to database" do
       user = create_scim_user

--- a/packages/two_percent/spec/models/scim_group_spec.rb
+++ b/packages/two_percent/spec/models/scim_group_spec.rb
@@ -300,13 +300,6 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
 
         expect(group.scim_users).to include(user1, user2)
       end
-
-      it "stores correlation_id on created memberships" do
-        group.replace_members(members_array, "corr-123")
-
-        memberships = group.scim_group_memberships
-        expect(memberships.pluck(:correlation_id).uniq).to eq(["corr-123"])
-      end
     end
 
     context "when removing members" do

--- a/packages/two_percent/spec/models/scim_group_spec.rb
+++ b/packages/two_percent/spec/models/scim_group_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
 
       it "creates memberships for new members" do
         expect do
-          group.replace_members(members_array, "corr-123")
+          group.replace_members(members_array)
         end.to change { group.scim_group_memberships.count }.by(2)
 
         expect(group.scim_users).to include(user1, user2)
@@ -315,7 +315,7 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
 
       it "removes memberships not in the array" do
         expect do
-          group.replace_members(members_array, "corr-456")
+          group.replace_members(members_array)
         end.to change { group.scim_group_memberships.count }.by(-2)
 
         group.reload
@@ -339,7 +339,7 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
       it "does not duplicate existing memberships" do
         # Only adds user2
         expect do
-          group.replace_members(members_array, "corr-789")
+          group.replace_members(members_array)
         end.to change { group.scim_group_memberships.count }.by(1)
         expect(group.scim_users).to include(user1, user2)
       end
@@ -353,7 +353,7 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
 
       it "removes all memberships" do
         expect do
-          group.replace_members([], "corr-empty")
+          group.replace_members([])
         end.to change { group.scim_group_memberships.count }.from(2).to(0)
       end
     end
@@ -365,7 +365,7 @@ RSpec.describe TwoPercent::ScimGroup, type: :model do
 
       it "raises error for non-existent users" do
         expect do
-          group.replace_members(members_array, "corr-404")
+          group.replace_members(members_array)
         end.to raise_error(ArgumentError, /Cannot add non-existent users to group: nonexistent-user/)
       end
     end


### PR DESCRIPTION
This PR removes unneeded correlation_id on ScimGroupMemberships. It was accidentally introduced in a previous PR.

The ticket for this PR is [here](https://runway.powerhrg.com/backlog_items/SHD-1926).