### PR TITLE
[SHD-1945] - Consent 2.6.1 Bugfix

### DIFF
--- a/packages/consent/Gemfile.lock
+++ b/packages/consent/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    consent (2.6.0)
+    consent (2.6.1)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/docs/CHANGELOG.md
+++ b/packages/consent/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### [2.6.1] - 2026-06-26
+
+- Fixed an issue where view and action comparisons did not work unless we converted their keys to strings. [#444](https://github.com/powerhome/power-tools/pull/444)
+
 ### [2.6.0] - 2026-06-15
 
 - Changed permission checksum calculation to use permission data rather than permission file contents. [#438](https://github.com/powerhome/power-tools/pull/438)

--- a/packages/consent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    consent (2.6.0)
+    consent (2.6.1)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_2.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    consent (2.6.0)
+    consent (2.6.1)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/lib/consent/action.rb
+++ b/packages/consent/lib/consent/action.rb
@@ -33,7 +33,7 @@ module Consent
     end
 
     def <=>(other)
-      key <=> other.key
+      key.to_s <=> other.key.to_s
     end
   end
 end

--- a/packages/consent/lib/consent/version.rb
+++ b/packages/consent/lib/consent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consent
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end

--- a/packages/consent/lib/consent/view.rb
+++ b/packages/consent/lib/consent/view.rb
@@ -31,7 +31,7 @@ module Consent
     end
 
     def <=>(other)
-      key <=> other.key
+      key.to_s <=> other.key.to_s
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where string and symbol keys would prevent comparisons between views and actions. This fix converts all keys into strings before comparison.