### PR TITLE
Lazily load subject keys

### DIFF
--- a/packages/consent/Gemfile.lock
+++ b/packages/consent/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: .
   specs:
-    consent (2.6.1)
+    consent (2.7.0)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/docs/CHANGELOG.md
+++ b/packages/consent/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### [2.7.0] - 2026-08-11
+
+- Lazily load model subjects [#447](https://github.com/powerhome/power-tools/pull/447)
+
 ### [2.6.1] - 2026-06-26
 
 - Fixed an issue where view and action comparisons did not work unless we converted their keys to strings. [#444](https://github.com/powerhome/power-tools/pull/444)

--- a/packages/consent/gemfiles/rails_7_1.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_1.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    consent (2.6.1)
+    consent (2.7.0)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/gemfiles/rails_7_2.gemfile.lock
+++ b/packages/consent/gemfiles/rails_7_2.gemfile.lock
@@ -11,7 +11,7 @@ PATH
 PATH
   remote: ..
   specs:
-    consent (2.6.1)
+    consent (2.7.0)
       cancancan (= 3.2.1)
 
 GEM

--- a/packages/consent/lib/consent/engine.rb
+++ b/packages/consent/lib/consent/engine.rb
@@ -10,10 +10,6 @@ module Consent
       config.consent = Consent::Reloader.new(default_path)
     end
 
-    config.after_initialize do |app|
-      app.config.consent.execute
-    end
-
     initializer "consent.reloader" do |app|
       app.reloaders << config.consent
       ActiveSupport::Dependencies.autoload_paths -= config.consent.paths

--- a/packages/consent/lib/consent/subject.rb
+++ b/packages/consent/lib/consent/subject.rb
@@ -2,13 +2,17 @@
 
 module Consent
   class Subject # :nodoc:
-    attr_reader :key, :label, :actions, :views
+    attr_reader :label, :actions, :views
 
     def initialize(key, label)
-      @key = key
+      @raw_key = key.respond_to?(:name) ? key.name : key
       @label = label
       @actions = []
       @views = Consent.default_views.clone
+    end
+
+    def key
+      Consent::SubjectCoder.load(@raw_key)
     end
 
     def to_permission_payload

--- a/packages/consent/lib/consent/version.rb
+++ b/packages/consent/lib/consent/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Consent
-  VERSION = "2.6.1"
+  VERSION = "2.7.0"
 end

--- a/packages/consent/spec/consent/subject_spec.rb
+++ b/packages/consent/spec/consent/subject_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Consent::Subject do
 
       expect(another_subect.key).to be ExampleModel
     end
+
+    it "is the symbol even when defined as a symbol" do
+      another_subect = Consent::Subject.new(:my_subject, "Subject")
+
+      expect(another_subect.key).to be :my_subject
+    end
   end
 
   describe "#views" do

--- a/packages/consent/spec/consent/subject_spec.rb
+++ b/packages/consent/spec/consent/subject_spec.rb
@@ -3,12 +3,24 @@
 require "spec_helper"
 
 RSpec.describe Consent::Subject do
-  subject { Consent::Subject.new(:subject, "Subject") }
+  subject { Consent::Subject.new(ExampleModel, "Subject") }
   let(:view) { Consent::View.new(:view, "View") }
   let(:action) { Consent::Action.new(subject, :action, "Action") }
   before do
     Consent.default_views[:view] = view
     subject.actions << action
+  end
+
+  describe "#key" do
+    it "is a lazily loaded reference to the actual subject" do
+      expect(subject.key).to be ExampleModel
+    end
+
+    it "is the model even when defined as a string" do
+      another_subect = Consent::Subject.new("ExampleModel", "Subject")
+
+      expect(another_subect.key).to be ExampleModel
+    end
   end
 
   describe "#views" do
@@ -20,7 +32,7 @@ RSpec.describe Consent::Subject do
   describe "#to_permission_payload" do
     it "returns the correct hash" do
       expect(subject.to_permission_payload).to eq({
-                                                    subject: :subject,
+                                                    subject: ExampleModel,
                                                     label: "Subject",
                                                     actions: [action.to_permission_payload],
                                                     views: [view.to_permission_payload],


### PR DESCRIPTION
Subjects declared with a model class no longer force that class to load when
permissions are defined. `Consent::Subject` stores the raw key name and resolves
it through `SubjectCoder` only when `#key` is called.

- Store the subject key as a string and constantize lazily in `Subject#key`
- Drop the `after_initialize` hook in the engine, which eagerly executed the
  reloader (and therefore loaded every subject) on boot — the reloader already
  runs on demand
- Specs covering symbol/string subject keys
- Release 2.7.0
